### PR TITLE
geometry_toolsのテストを追加

### DIFF
--- a/consai_robot_controller/CMakeLists.txt
+++ b/consai_robot_controller/CMakeLists.txt
@@ -99,6 +99,8 @@ install(TARGETS
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_gtest)
+  ament_add_gtest(geometry_tools_test test/geometry_tools_test.cpp)
 endif()
 
 ament_package()

--- a/consai_robot_controller/CMakeLists.txt
+++ b/consai_robot_controller/CMakeLists.txt
@@ -105,7 +105,6 @@ if(BUILD_TESTING)
     consai_msgs
     robocup_ssl_msgs
   )
-rclcpp_components_register_nodes(grsim_command_converter "consai_robot_controller::GrSimCommandConverter")
 endif()
 
 ament_package()

--- a/consai_robot_controller/CMakeLists.txt
+++ b/consai_robot_controller/CMakeLists.txt
@@ -100,7 +100,12 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # ament_lint_auto_find_test_dependencies()
   find_package(ament_cmake_gtest)
-  ament_add_gtest(geometry_tools_test test/geometry_tools_test.cpp)
+  ament_add_gtest(geometry_tools_test test/geometry_tools_test.cpp src/geometry_tools.cpp)
+  ament_target_dependencies(geometry_tools_test
+    consai_msgs
+    robocup_ssl_msgs
+  )
+rclcpp_components_register_nodes(grsim_command_converter "consai_robot_controller::GrSimCommandConverter")
 endif()
 
 ament_package()

--- a/consai_robot_controller/package.xml
+++ b/consai_robot_controller/package.xml
@@ -20,6 +20,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/consai_robot_controller/test/README.md
+++ b/consai_robot_controller/test/README.md
@@ -4,6 +4,8 @@
 
 ```sh
 $ cd ros2_ws
+# パッケージを選択してビルドを実行
+$  colcon build --symlink-install --packages-select consai_robot_controller
 
 # パッケージを選択してテストを実行
 $ colcon test --packages-select consai_robot_controller

--- a/consai_robot_controller/test/README.md
+++ b/consai_robot_controller/test/README.md
@@ -5,7 +5,7 @@
 ```sh
 $ cd ros2_ws
 # パッケージを選択してビルドを実行
-$  colcon build --symlink-install --packages-select consai_robot_controller
+$ colcon build --symlink-install --packages-select consai_robot_controller
 
 # パッケージを選択してテストを実行
 $ colcon test --packages-select consai_robot_controller

--- a/consai_robot_controller/test/README.md
+++ b/consai_robot_controller/test/README.md
@@ -1,0 +1,13 @@
+# テスト
+
+## テストの実行方法
+
+```sh
+$ cd ros2_ws
+
+# パッケージを選択してテストを実行
+$ colcon test --packages-select consai_robot_controller
+
+# テスト結果の表示
+$ colcon test-result --verbose
+```

--- a/consai_robot_controller/test/geometry_tools_test.cpp
+++ b/consai_robot_controller/test/geometry_tools_test.cpp
@@ -13,7 +13,11 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include "consai_robot_controller/geometry_tools.hpp"
 
-TEST(TestGeometryTools, hoge) {
-  EXPECT_EQ(2, 1+1);
+TEST(TestGeometryTools, to_radians) {
+  const double ABS_ERROR = 0.00001;
+  EXPECT_NEAR(geometry_tools::to_radians(0), 0, ABS_ERROR);
+  EXPECT_NEAR(geometry_tools::to_radians(180), 3.141592, ABS_ERROR);
+  EXPECT_NEAR(geometry_tools::to_radians(-180), -3.141592, ABS_ERROR);
 }

--- a/consai_robot_controller/test/geometry_tools_test.cpp
+++ b/consai_robot_controller/test/geometry_tools_test.cpp
@@ -15,5 +15,5 @@
 #include <gtest/gtest.h>
 
 TEST(TestGeometryTools, hoge) {
-  EXPECT_EQ(0, 1+1);
+  EXPECT_EQ(2, 1+1);
 }

--- a/consai_robot_controller/test/geometry_tools_test.cpp
+++ b/consai_robot_controller/test/geometry_tools_test.cpp
@@ -1,0 +1,19 @@
+// Copyright 2022 Roots
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+TEST(TestGeometryTools, hoge) {
+  EXPECT_EQ(0, 1+1);
+}


### PR DESCRIPTION
geometry_toolsにユニットテストを追加します。

テストの実行方法はREADMEに記載しています。