### PR TITLE
優勝パス関数実装

### DIFF
--- a/consai_examples/consai_examples/control.py
+++ b/consai_examples/consai_examples/control.py
@@ -329,7 +329,7 @@ def find_passable_robots(robot_id, select_forward_between):
     # パスができる味方ロボットを探す
     # select_forward_betweenは
     # 0であれば前方の相手ロボットすべてを対象にする
-    # 1であればパサーと味方ロボットの間にいる相手ロボットを対象にする
+    # 1であればパサーとレシーバー候補となる味方ロボットの間にいる相手ロボットを対象にする
     while rclpy.ok():
         our_robots_pos = observer_node.get_our_robots_pos()
         their_robots_pos = observer_node.get_their_robots_pos()

--- a/consai_examples/consai_examples/control.py
+++ b/consai_examples/consai_examples/control.py
@@ -325,18 +325,21 @@ def test_refelect_shoot_four_robots(id1, id2, id3, id4):
     while operator_node.all_robots_are_free() is False:
         pass
 
-def test_prototyping():
+def find_passable_robots(robot_id, select_forward_between):
+    # パスができる味方ロボットを探す
+    # select_forward_betweenは
+    # 0であれば前方の相手ロボットすべてを対象にする
+    # 1であればパサーと味方ロボットの間にいる相手ロボットを対象にする
     while rclpy.ok():
         our_robots_pos = observer_node.get_our_robots_pos()
         their_robots_pos = observer_node.get_their_robots_pos()
         our_robots_vel = observer_node.get_our_robots_vel()
         their_robots_vel = observer_node.get_their_robots_vel()
-        ball_pos = observer_node.get_ball_pos()
 
         if len(our_robots_pos) > 0:
             break
 
-    robots_to_pass = operator_node.search_for_pass_cource(4, our_robots_pos, our_robots_vel, their_robots_pos, their_robots_vel, ball_pos)
+    robots_to_pass = operator_node.search_for_pass_cource(robot_id, our_robots_pos, our_robots_vel, their_robots_pos, their_robots_vel, select_forward_between)
     print(robots_to_pass)
 
 def main():
@@ -356,7 +359,7 @@ def main():
     # test_defend_goal_on_line(-1.0, 1.0, -1.0, -1.0)
     # test_reflect_shoot(0, 0, 0)
     # test_refelect_shoot_four_robots(0, 1, 2, 3)
-    test_prototyping()
+    find_passable_robots(4, 1)
 
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()

--- a/consai_examples/consai_examples/control.py
+++ b/consai_examples/consai_examples/control.py
@@ -325,7 +325,7 @@ def test_refelect_shoot_four_robots(id1, id2, id3, id4):
     while operator_node.all_robots_are_free() is False:
         pass
 
-def find_passable_robots(robot_id, select_forward_between):
+def find_passable_robots(robot_id_has_ball, select_forward_between):
     # パスができる味方ロボットを探す
     # select_forward_betweenは
     # 0であれば前方の相手ロボットすべてを対象にする
@@ -339,7 +339,7 @@ def find_passable_robots(robot_id, select_forward_between):
         if len(our_robots_pos) > 0:
             break
 
-    robots_to_pass = operator_node.search_for_pass_cource(robot_id, our_robots_pos, our_robots_vel, their_robots_pos, their_robots_vel, select_forward_between)
+    robots_to_pass = operator_node.search_for_pass_cource(robot_id_has_ball, our_robots_pos, our_robots_vel, their_robots_pos, their_robots_vel, select_forward_between)
     print(robots_to_pass)
 
 def main():

--- a/consai_examples/consai_examples/control.py
+++ b/consai_examples/consai_examples/control.py
@@ -20,9 +20,11 @@ import math
 import threading
 import time
 
+from field_observer import FieldObserver
 import rclpy
 from rclpy.executors import MultiThreadedExecutor
 from robot_operator import RobotOperator
+from referee_parser import RefereeParser
 
 
 def test_move_to(max_velocity_xy=None):
@@ -323,9 +325,23 @@ def test_refelect_shoot_four_robots(id1, id2, id3, id4):
     while operator_node.all_robots_are_free() is False:
         pass
 
+def test_prototyping():
+    while rclpy.ok():
+        our_robots_pos = observer_node.get_our_robots_pos()
+        their_robots_pos = observer_node.get_their_robots_pos()
+        our_robots_vel = observer_node.get_our_robots_vel()
+        their_robots_vel = observer_node.get_their_robots_vel()
+        ball_pos = observer_node.get_ball_pos()
+
+        if len(our_robots_pos) > 0:
+            break
+
+    robots_to_pass = operator_node.search_for_pass_cource(4, our_robots_pos, our_robots_vel, their_robots_pos, their_robots_vel, ball_pos)
+    print(robots_to_pass)
+
 def main():
     # 実行したい関数のコメントを外してください
-    test_move_to()
+    # test_move_to()
     # test_move_to(1.5)  # 走行速度を1.0 m/sに制限
     # test_move_to_normalized(3)
     # test_chase_ball()
@@ -340,6 +356,7 @@ def main():
     # test_defend_goal_on_line(-1.0, 1.0, -1.0, -1.0)
     # test_reflect_shoot(0, 0, 0)
     # test_refelect_shoot_four_robots(0, 1, 2, 3)
+    test_prototyping()
 
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()
@@ -347,11 +364,17 @@ if __name__ == '__main__':
                             default=False,
                             action='store_true',
                             help='yellowロボットを動かす場合にセットする')
+    arg_parser.add_argument('--invert',
+                            default=False,
+                            action='store_true',
+                            help='ball placementの目標座標を反転する場合にセットする')
     args = arg_parser.parse_args()
 
     rclpy.init(args=None)
 
     operator_node = RobotOperator(target_is_yellow=args.yellow)
+    observer_node = FieldObserver(args.yellow)
+    referee_node = RefereeParser(args.yellow, args.invert)
 
     # すべてのロボットの衝突回避を解除
     for i in range(16):
@@ -359,6 +382,8 @@ if __name__ == '__main__':
 
     executor = MultiThreadedExecutor()
     executor.add_node(operator_node)
+    executor.add_node(observer_node)
+    executor.add_node(referee_node)
 
     # エグゼキュータは別スレッドでspinさせ続ける
     executor_thread = threading.Thread(target=executor.spin, daemon=True)

--- a/consai_examples/consai_examples/field_observer.py
+++ b/consai_examples/consai_examples/field_observer.py
@@ -72,11 +72,13 @@ class FieldObserver(Node):
         self.our_robots_angle = []
         self.our_robots_vel = []
         self.our_robots_speed = []
+        self.our_robots_vel_angle = []
 
         self.their_robots_pos = []
         self.their_robots_angle = []
         self.their_robots_vel = []
         self.their_robots_speed = []
+        self.their_robots_vel_angle = []
 
         self._field_x = 12.0  # meters
         self._field_half_x = self._field_x * 0.5
@@ -99,29 +101,27 @@ class FieldObserver(Node):
         if len(msg.robots) > 0:
             self.robots = msg.robots
             if self._our_team_is_yellow:
-                self._update_our_robots_pos(
-                    [msg.robots[our_robot] for our_robot in range(16, 32)])
-                self._update_their_robots_pos(
-                    [msg.robots[their_robot] for their_robot in range(16)])
-                self._update_our_robots_vel(
-                    [msg.robots[our_robot] for our_robot in range(16, 32)])
-                self._update_their_robots_vel(
-                    [msg.robots[their_robot] for their_robot in range(16)])
-                self._our_robot = [msg.robots[robot]
-                                   for robot in range(16, 32)]
+                self._update_our_robots_pos([msg.robots[our_robot] for our_robot in range(16, 32)])
+                self._update_their_robots_pos([msg.robots[their_robot] for their_robot in range(16)])
+                self._update_our_robots_vel([msg.robots[our_robot] for our_robot in range(16, 32)])
+                self._update_their_robots_vel([msg.robots[their_robot] for their_robot in range(16)])
+                self._update_our_robots_thita([msg.robots[our_robot] for our_robot in range(16, 32)])
+                self._update_their_robots_thita([msg.robots[their_robot] for their_robot in range(16)])
+                self._update_our_robots_vel_angle([msg.robots[our_robot] for our_robot in range(16, 32)])
+                self._update_their_robots_vel_angle([msg.robots[their_robot] for their_robot in range(16)])
+                self._our_robot = [msg.robots[robot] for robot in range(16, 32)]
                 self._their_robot = [msg.robots[robot] for robot in range(16)]
             elif not self._our_team_is_yellow:
-                self._update_our_robots_pos(
-                    [msg.robots[our_robot] for our_robot in range(16)])
-                self._update_their_robots_pos(
-                    [msg.robots[their_robot] for their_robot in range(16, 32)])
-                self._update_our_robots_vel(
-                    [msg.robots[our_robot] for our_robot in range(16)])
-                self._update_their_robots_vel(
-                    [msg.robots[their_robot] for their_robot in range(16, 32)])
+                self._update_our_robots_pos([msg.robots[our_robot] for our_robot in range(16)])
+                self._update_their_robots_pos([msg.robots[their_robot] for their_robot in range(16, 32)])
+                self._update_our_robots_vel([msg.robots[our_robot] for our_robot in range(16)])
+                self._update_their_robots_vel([msg.robots[their_robot] for their_robot in range(16, 32)])
+                self._update_our_robots_thita([msg.robots[our_robot] for our_robot in range(16)])
+                self._update_their_robots_thita([msg.robots[their_robot] for their_robot in range(16, 32)])
+                self._update_our_robots_vel_angle([msg.robots[our_robot] for our_robot in range(16)])
+                self._update_their_robots_vel_angle([msg.robots[their_robot] for their_robot in range(16, 32)])
                 self._our_robot = [msg.robots[robot] for robot in range(16)]
-                self._their_robot = [msg.robots[robot]
-                                     for robot in range(16, 32)]
+                self._their_robot = [msg.robots[robot] for robot in range(16, 32)]
 
     def update_robot_state(self):
         return self.robots
@@ -150,37 +150,49 @@ class FieldObserver(Node):
 
     # 味方ロボットの速度 [x,y] 取得
     def _update_our_robots_vel(self, our_robots):
-        self.our_robots_vel = [
-            our_robots[robot].vel for robot in range(len(our_robots))]
+        self.our_robots_vel = [our_robots[robot].vel for robot in range(len(our_robots))]
         self.our_robots_vel = sum(self.our_robots_vel, [])
-        self.our_robots_vel = ["None" if our_robots[robot].visibility[0] <= 0.2 else [
-            self.our_robots_vel[robot].x, self.our_robots_vel[robot].y] for robot in range(len(self.our_robots_vel))]
+        self.our_robots_vel = ["None" if our_robots[robot].visibility[0] <= 0.2 else [self.our_robots_vel[robot].x, self.our_robots_vel[robot].y] for robot in range(len(self.our_robots_vel))]
 
     def get_our_robots_vel(self):
         return self.our_robots_vel
 
     # 相手ロボットの速度 [x,y] 取得
-
     def _update_their_robots_vel(self, their_robots):
-        self.their_robots_vel = [
-            their_robots[robot].vel for robot in range(len(their_robots))]
+        self.their_robots_vel = [their_robots[robot].vel for robot in range(len(their_robots))]
         self.their_robots_vel = sum(self.their_robots_vel, [])
-        self.their_robots_vel = ["None" if their_robots[robot].visibility[0] <= 0.2 else [
-            self.their_robots_vel[robot].x, self.their_robots_vel[robot].y] for robot in range(len(self.their_robots_vel))]
+        self.their_robots_vel = ["None" if their_robots[robot].visibility[0] <= 0.2 else [self.their_robots_vel[robot].x, self.their_robots_vel[robot].y] for robot in range(len(self.their_robots_vel))]
 
     def get_their_robots_vel(self):
         return self.their_robots_vel
 
-    def update_our_robots_thita(self):
-        our_robots_thita = [
-            self._our_robot[robot].orientation for robot in range(len(self._our_robot))]
-        return our_robots_thita
+    # 味方ロボットの向いている角度（rad）取得
+    def _update_our_robots_thita(self, our_robots):
+        self.our_robots_angle = [our_robots[robot].orientation for robot in range(len(our_robots))]
+    
+    def get_our_robots_thita(self):
+        return self.our_robots_angle
+    
+    # 相手ロボットの向いている角度（rad）取得
+    def _update_their_robots_thita(self, their_robots):
+        self.our_robots_angle = [their_robots[robot].orientation for robot in range(len(their_robots))]
+    
+    def get_their_robots_thita(self):
+        return self.their_robots_angle
 
-    # 味方ロボットの角速度取得
-    def update_our_robots_vel_angle(self):
-        our_robots_vel_angle = [
-            self._our_robot[robot].vel_angular[0] for robot in range(len(self._our_robot))]
-        return our_robots_vel_angle
+    # 味方ロボットの角速度（rad/s）取得
+    def _update_our_robots_vel_angle(self, our_robots):
+        self.our_robots_vel_angle = [our_robots[robot].vel_angular[0] for robot in range(len(our_robots))]
+
+    def get_our_robots_vel_angle(self):
+        return self.our_robots_vel_angle
+    
+    # 相手ロボットの角速度（rad/s）取得
+    def _update_their_robots_vel_angle(self, their_robots):
+        self.their_robots_vel_angle = [their_robots[robot].vel_angular[0] for robot in range(len(their_robots))]
+
+    def get_their_robots_vel_angle(self):
+        return self.their_robots_vel_angle
 
     def _update_ball_state(self, ball):
         # フィールド場外判定
@@ -598,4 +610,5 @@ class FieldObserver(Node):
         return self._ball_placement_state
 
     def get_ball_pos(self):
-        return self._ball
+        ball_pos = [self._ball.pos.x, self._ball.pos.y]
+        return ball_pos

--- a/consai_examples/consai_examples/robot_operator.py
+++ b/consai_examples/consai_examples/robot_operator.py
@@ -701,6 +701,8 @@ class RobotOperator(Node):
     def search_for_pass_cource(self, robot_id_has_ball, our_robots_pos, our_robots_vel, their_robots_pos, their_robots_vel, select_forward_between):
         # パス可能ロボットのIDを格納するリスト
         robots_to_pass = []
+        # 計算対象にする相手ロボットのIDを格納するリスト
+        target_their_robots_id = []
         # 計算上の相手ロボットの半径（通常の倍の半径（直径）に設定）
         their_robot_r = 0.4
         # 前方にいる相手ロボットの数と比較する用の変数
@@ -748,8 +750,10 @@ class RobotOperator(Node):
 
             if select_forward_between == 1:
                 target_their_robots_id = [robot_id for robot_id in forward_their_robots_id if our_robots_pos[dist_our_robot[i][1]][0] > their_robots_pos[robot_id][0]]
+            else:
+                target_their_robots_id = forward_their_robots_id
 
-            if len(target_their_robots_id) != 0:
+            if len(target_their_robots_id) > 0:
                 for robot_id in target_their_robots_id:
                     # 判別式
                     a_kai = slope ** 2 + 1
@@ -766,7 +770,7 @@ class RobotOperator(Node):
                             check_count += 1
                     else:
                         check_count = 0
-                        print(i, "番の味方ロボットへのパスは", robot_id, "番の相手ロボットに防がれる可能性あり")
+                        print(dist_our_robot[i][1], "番の味方ロボットへのパスは", robot_id, "番の相手ロボットに防がれる可能性あり")
                         break
             else:
                 robots_to_pass.append(dist_our_robot[i][1])

--- a/consai_examples/consai_examples/robot_operator.py
+++ b/consai_examples/consai_examples/robot_operator.py
@@ -704,83 +704,104 @@ class RobotOperator(Node):
         # 計算対象にする相手ロボットのIDを格納するリスト
         target_their_robots_id = []
         # 計算上の相手ロボットの半径（通常の倍の半径（直径）に設定）
-        their_robot_r = 0.4
+        robot_r = 0.4
         # 前方にいる相手ロボットの数と比較する用の変数
         check_count = 0
         # ロボットの位置座標取得から実際にパスを出すまでの想定時間
         dt = 0.5
 
+        # フィールド上にいるロボットのIDのみリストに格納する
         their_robots_in_field = [robot_id for robot_id in range(len(their_robots_pos)) if their_robots_pos[robot_id] != "None"]
         our_robots_in_field = [robot_id for robot_id in range(len(our_robots_pos)) if our_robots_pos[robot_id] != "None"]
 
         # パサーよりも前にいるロボットIDをリストにまとめる
         # 相手ロボットに対して
         forward_their_robots_id = [robot_id for robot_id in their_robots_in_field 
-                                  if our_robots_pos[robot_id_has_ball][0] < their_robots_pos[robot_id][0] + (their_robots_vel[robot_id][0] * dt + their_robot_r) * 
-                                  their_robots_pos[robot_id][0] / math.sqrt(their_robots_pos[robot_id][0] ** 2 + their_robots_pos[robot_id][1] ** 2)]
+                                  if our_robots_pos[robot_id_has_ball][0] < their_robots_pos[robot_id][0] + (abs(their_robots_vel[robot_id][0]) * dt + robot_r) * 
+                                  their_robots_vel[robot_id][0] / math.sqrt(their_robots_vel[robot_id][0] ** 2 + their_robots_vel[robot_id][1] ** 2)]
         # 味方ロボットに対して
         forward_our_robots_id = [robot_id for robot_id in our_robots_in_field 
-                                if our_robots_pos[robot_id] != "None" and 
-                                our_robots_pos[robot_id_has_ball][0] < our_robots_pos[robot_id][0] + (our_robots_vel[robot_id][0] * dt + their_robot_r) * 
-                                our_robots_pos[robot_id][0] / math.sqrt(our_robots_pos[robot_id][0] ** 2 + our_robots_pos[robot_id][1] ** 2)]
+                                if robot_id != robot_id_has_ball and our_robots_pos[robot_id_has_ball][0] < our_robots_pos[robot_id][0] + (abs(our_robots_vel[robot_id][0]) * dt + robot_r) * 
+                                our_robots_vel[robot_id][0] / math.sqrt(our_robots_vel[robot_id][0] ** 2 + our_robots_vel[robot_id][1] ** 2)]
 
         # パサーよりも前にいるロボットがいなければ空のリストを返す
         if forward_our_robots_id == 0:
             return forward_our_robots_id
 
-        # ロボットの位置と長半径（移動距離）をロボットごとに格納
-        their_robot_state = [[their_robots_pos[i][0], their_robots_pos[i][1], dt * their_robots_vel[i][0] + their_robot_r] for i in forward_their_robots_id]
-        
         # ボールから味方のロボットまでの距離を計測し，近い順にソートする
         dist_our_robot = self._sort_passer_from_our_robot_distance(robot_id_has_ball, forward_our_robots_id, our_robots_pos)
-        their_robot_count = len(forward_their_robots_id)
+
+        # ロボットの位置と長半径（移動距離）をロボットごとに格納
+        their_robot_state = [[their_robots_pos[i][0], their_robots_pos[i][1], dt * abs(their_robots_vel[i][0]) + robot_r] for i in forward_their_robots_id]
 
         # 解を求める
         # 味方ロボットとボールまでの直線の方程式
         for i in range(len(dist_our_robot)):
-            # x差分
-            x = our_robots_pos[dist_our_robot[i][1]][0] - our_robots_pos[robot_id_has_ball][0]
-            # y差分
-            y = our_robots_pos[dist_our_robot[i][1]][1] - our_robots_pos[robot_id_has_ball][1]
+            # パサーとレシーバー候補となる味方ロボットのx座標差分
+            dx = our_robots_pos[dist_our_robot[i][1]][0] - our_robots_pos[robot_id_has_ball][0]
+            # パサーとレシーバー候補となる味方ロボットのy座標差分
+            dy = our_robots_pos[dist_our_robot[i][1]][1] - our_robots_pos[robot_id_has_ball][1]
 
-            # 傾き
-            slope = y/x
-            # 切片
-            intercept = y - slope * x
+            # パサーとレシーバー候補となる味方ロボットを結ぶ直線の傾き
+            if dx == 0:
+                slope_from_passer_to_our_robot = dy
+            else:
+                slope_from_passer_to_our_robot = dy / dx
+            # パサーとレシーバー候補となる味方ロボットを結ぶ直線の切片
+            intercept_from_passer_to_our_robot = our_robots_pos[robot_id_has_ball][1] - slope_from_passer_to_our_robot * our_robots_pos[robot_id_has_ball][0]
 
+            # パサーとレシーバー候補となる味方ロボットの間にいる相手ロボットを計算対象とするときの処理
             if select_forward_between == 1:
                 target_their_robots_id = [robot_id for robot_id in forward_their_robots_id if our_robots_pos[dist_our_robot[i][1]][0] > their_robots_pos[robot_id][0]]
+            # パサーより前方にいる相手ロボットを計算対象とするときの処理
             else:
                 target_their_robots_id = forward_their_robots_id
 
-            if len(target_their_robots_id) > 0:
+            # 計算対象とする相手ロボットが存在するときの処理
+            if len(target_their_robots_id) != 0:
+                # 対象とする相手ロボット全てに対してパスコースを妨げるような動きをしているか計算
                 for robot_id in target_their_robots_id:
-                    # 判別式
-                    a_kai = slope ** 2 + 1
-                    b_kai = 2 * ((intercept - their_robot_state[robot_id][1]) * slope - their_robot_state[robot_id][0])
-                    c_kai = their_robot_state[robot_id][0] ** 2 + (intercept - their_robot_state[robot_id][1]) ** 2 - their_robot_state[robot_id][2] ** 2
+                    # 判別式を解くための変数
+                    a_kai = slope_from_passer_to_our_robot ** 2 + 1
+                    b_kai = 2 * ((intercept_from_passer_to_our_robot - their_robot_state[robot_id][1]) * slope_from_passer_to_our_robot - their_robot_state[robot_id][0])
+                    c_kai = their_robot_state[robot_id][0] ** 2 + (intercept_from_passer_to_our_robot - their_robot_state[robot_id][1]) ** 2 - their_robot_state[robot_id][2] ** 2
 
-                    distance = b_kai ** 2 - 4 * a_kai * c_kai
+                    # 共有点を持つか判定
+                    common_point = b_kai ** 2 - 4 * a_kai * c_kai
 
-                    if distance < 0:
-                        if check_count >= their_robot_count - 1:
+                    # 共有点を持たないときの処理
+                    if common_point < 0:
+                        # 対象としている相手ロボットすべてにパスコースが妨害されないときの処理
+                        if check_count >= len(target_their_robots_id) - 1:
+                            # 何台の相手ロボットに妨害されないかをカウントする変数をリセット
                             check_count = 0
+                            # パスできる味方ロボットとしてリストに格納
                             robots_to_pass.append(dist_our_robot[i][1])
+                        # まだすべてのロボットに対して計算を行っていない場合の処理
                         else:
+                            # 何台の相手ロボットに妨害されないかをカウントする変数をインクリメント
                             check_count += 1
+                    # 共有点を持つときの処理
                     else:
+                        # 何台の相手ロボットに妨害されないかをカウントする変数をリセット
                         check_count = 0
+                        # どの相手ロボットがパスコースに影響していたか（1台のみ出力）
+                        # このときの味方ロボットはパスの候補から除外する
                         print(dist_our_robot[i][1], "番の味方ロボットへのパスは", robot_id, "番の相手ロボットに防がれる可能性あり")
                         break
+            # 計算対象とする相手ロボットが存在しないとき（邪魔する相手ロボットがいないとき）
             else:
+                # パスができる味方ロボットとしてリストに格納
                 robots_to_pass.append(dist_our_robot[i][1])
         
         return robots_to_pass
 
+    # パサーからレシーバー候補となる味方ロボットまでの距離を計算し，近い順にソートする関数
     def _sort_passer_from_our_robot_distance(self, robot_has_ball, our_robot_id, our_robots_pos):
-        # ボールから味方のロボットまでの距離を計算し，近い順にソートする関数
-        diff_ball_to_robot = [[our_robots_pos[our_robot_id[i]][0] - our_robots_pos[robot_has_ball][0], 
-                               our_robots_pos[our_robot_id[i]][1] - our_robots_pos[robot_has_ball][1]] for i in range(len(our_robot_id))]
-        receive_dist_our_robot = [[math.sqrt((diff_ball_to_robot[i][0]) ** 2 + (diff_ball_to_robot[i][1]) ** 2), our_robot_id[i]] for i in range(len(our_robot_id))]
+        # パサーからレシーバー候補となる味方ロボットまでの距離、レシーバー候補となる味方ロボットのIDをリストに格納
+        diff_passer_to_our_robot = [[our_robots_pos[i][0] - our_robots_pos[robot_has_ball][0], our_robots_pos[i][1] - our_robots_pos[robot_has_ball][1]] for i in our_robot_id]
+        # パサーからレシーバー候補となる味方ロボットまでの距離、レシーバー候補となる味方ロボットのIDをリストに格納
+        receive_dist_our_robot = [[math.sqrt((diff_passer_to_our_robot[i][0]) ** 2 + (diff_passer_to_our_robot[i][1]) ** 2), our_robot_id[i]] for i in range(len(our_robot_id))]
+        # パサーに近い順に味方ロボットをソート
         receive_dist_our_robot = sorted(receive_dist_our_robot)
         return receive_dist_our_robot

--- a/consai_examples/consai_examples/robot_operator.py
+++ b/consai_examples/consai_examples/robot_operator.py
@@ -732,9 +732,9 @@ class RobotOperator(Node):
         their_robot_state = [[their_robots_pos[i][0], their_robots_pos[i][1], dt * their_robots_vel[i][0] + their_robot_r] for i in forward_their_robots_id]
         
         # ボールから味方のロボットまでの距離を計測し，近い順にソートする
-        dist_our_robot = self.sort_passer_from_our_robot_distance(robot_id_has_ball, forward_our_robots_id, our_robots_pos)
+        dist_our_robot = self._sort_passer_from_our_robot_distance(robot_id_has_ball, forward_our_robots_id, our_robots_pos)
         their_robot_count = len(forward_their_robots_id)
-        
+
         # 解を求める
         # 味方ロボットとボールまでの直線の方程式
         for i in range(len(dist_our_robot)):
@@ -777,7 +777,7 @@ class RobotOperator(Node):
         
         return robots_to_pass
 
-    def sort_passer_from_our_robot_distance(self, robot_has_ball, our_robot_id, our_robots_pos):
+    def _sort_passer_from_our_robot_distance(self, robot_has_ball, our_robot_id, our_robots_pos):
         # ボールから味方のロボットまでの距離を計算し，近い順にソートする関数
         diff_ball_to_robot = [[our_robots_pos[our_robot_id[i]][0] - our_robots_pos[robot_has_ball][0], 
                                our_robots_pos[our_robot_id[i]][1] - our_robots_pos[robot_has_ball][1]] for i in range(len(our_robot_id))]


### PR DESCRIPTION
## field_obserber.py
味方、相手ロボットの向いている方向[rad]、角速度[rad/s]が取得できるように変更

## robot_operator.py
優勝パス関数（search_for_pass_cource）とボールを保持したロボット（パサー）と味方ロボットとの距離がどれだけ離れているかを算出し、パサーに近い順にソートする関数（sort_ball_from_our_robot_distance）の実装

## control.py
優勝パス関数の実行例の追加
ロボットは動作せず関数のみが動作し、実行結果としてパス可能と判定した味方ロボットのIDをリストにまとめて出力
すべての味方ロボットにパスが出せなかった場合は空のリストが出力される