### PR TITLE
start.launch.pyからgame.pyを起動できる

### DIFF
--- a/consai_examples/README.md
+++ b/consai_examples/README.md
@@ -130,3 +130,36 @@ $ ros2 launch consai_examples start.launch.py yellow:=true invert:=true
 # ゴールキーパのIDを2とする
 $ ros2 run consai_examples control_with_role.py --goalie 2 --yellow
 ```
+
+## 試合をする
+
+`start.launch.py`に引数`game:=true`をセットすると、試合用のスクリプトが起動します。
+
+```sh
+$ ros2 launch consai_examples start.launch.py game:=true
+```
+
+また、黄色ロボットを動かすための`yellow`、
+逆サイドで動かすための`invert`、
+ゴールキーパーIDの`goalie`オプションも設定できます。
+
+```sh
+# 黄色ロボットを動かす かつ
+# 逆サイド かつ
+# ゴールキーパのIDが2
+$ ros2 launch consai_examples start.launch.py game:=true yellow:=true invert:=true goalie:=2
+```
+
+## CON-SAI vs CON-SAIで試合をする
+
+環境変数`ROS_DOMAIN_ID`を設定することでROSのネットワークを分離できます。
+
+これを応用して、CON-SAI vs CON-SAIで試合ができます。
+
+```sh
+# 青色チームを起動
+$ ROS_DOMAIN_ID=1 ros2 launch consai_examples start.launch.py game:=true
+
+# 別のターミナルで、逆サイドの黄色チームを起動
+$ ROS_DOMAIN_ID=2 ros2 launch consai_examples start.launch.py game:=true yellow:=true invert:=true
+```

--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -176,9 +176,9 @@ if __name__ == '__main__':
                             default=0,
                             type=int,
                             help='ゴールキーパのIDをセットする')
-    args = arg_parser.parse_args()
+    args, other_args = arg_parser.parse_known_args()
 
-    rclpy.init(args=None)
+    rclpy.init(args=other_args)
 
     operator = RobotOperator(args.yellow)
     assignor = RoleAssignment(args.goalie, args.yellow)

--- a/consai_examples/consai_examples/role_assignment.py
+++ b/consai_examples/consai_examples/role_assignment.py
@@ -52,6 +52,7 @@ class RoleAssignment(Node):
 
         self._role = [None] * self.ROLE_NUM
         self._goalie_id = goalie_id
+        self.get_logger().info('goalie IDは{}です'.format(self._goalie_id))
 
         self._detection = TrackedFrame()
         self._sub_detection_tracked = self.create_subscription(

--- a/consai_examples/launch/start.launch.py
+++ b/consai_examples/launch/start.launch.py
@@ -16,9 +16,12 @@ from ament_index_python.packages import get_package_share_directory
 import launch
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PythonExpression
 from launch_ros.actions import ComposableNodeContainer
+from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode
 
 
@@ -31,6 +34,16 @@ def generate_launch_description():
     declare_arg_yellow = DeclareLaunchArgument(
         'yellow', default_value='false',
         description=('Set "true" to control yellow team robots.')
+    )
+
+    declare_arg_game = DeclareLaunchArgument(
+        'game', default_value='false',
+        description=('Set "true" to run game script.')
+    )
+
+    declare_arg_goalie = DeclareLaunchArgument(
+        'goalie', default_value='0',
+        description=('Set goalie id for game script.')
     )
 
     controller = IncludeLaunchDescription(
@@ -56,9 +69,25 @@ def generate_launch_description():
                     name='game_controller')
             ])
 
+    cmd_arg_yellow = ['"--yellow" if "true" == "', LaunchConfiguration('yellow'), '" else ""']
+    cmd_arg_invert = ['"--invert" if "true" == "', LaunchConfiguration('invert'), '" else ""']
+    game_node = Node(package='consai_examples',
+                     executable='game.py',
+                     output='screen',
+                     arguments=[
+                        PythonExpression(cmd_arg_yellow),
+                        PythonExpression(cmd_arg_invert),
+                        '--goalie', LaunchConfiguration('goalie')
+                     ],
+                     condition=IfCondition(LaunchConfiguration('game')),
+                    )
+
     return launch.LaunchDescription([
         declare_arg_invert,
         declare_arg_yellow,
+        declare_arg_game,
+        declare_arg_goalie,
         controller,
-        container
+        container,
+        game_node
     ])


### PR DESCRIPTION
start.launch.pyに引数`game:=true`を与えることでgame.pyも一緒に起動できるようになりました。

コマンド数が減ってうれしいですね。

`yellow`、`invert`、`goalie`オプションにも対応してます。

また、CON-SAI vs CON-SAIを実行するためのドキュメントを追加してます。
consai_examplesのREADMEを確認してください。