### PR TITLE
controllerにて起動時にgeometryリソースがないのに参照していたところを修正

### DIFF
--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -337,6 +337,11 @@ bool FieldInfoParser::parse_constraint_xy(
 
   // フィールドサイズに対してx, yが-1 ~ 1に正規化されている
   if (xy.normalized) {
+    // フィールド情報がなければfalse
+    if (!geometry_) {
+      return false;
+    }
+
     parsed_x *= geometry_->field.field_length * 0.5 * 0.001;
     parsed_y *= geometry_->field.field_width * 0.5 * 0.001;
   }


### PR DESCRIPTION
start.launch.py 起動時にcontroller側のノードが落ちることを修正します。

ただし、レフェリー信号が変更されるまで一部のロボットが動かないという問題が出ました。

こちらはgame.py側で対策を考えます。