### PR TITLE
起動時のロボットのvisibilityを0.0に変更し、ロボットは存在しない状態からスタートさせる

### DIFF
--- a/consai_vision_tracker/src/robot_tracker.cpp
+++ b/consai_vision_tracker/src/robot_tracker.cpp
@@ -41,7 +41,7 @@ RobotTracker::RobotTracker(const int team_color, const int id, const double dt)
   prev_tracked_robot_.robot_id.team_color = team_color;
   prev_tracked_robot_.robot_id.id = id;
   // visibilityはoptionalなので、ここでデフォルト値を設定しておく
-  prev_tracked_robot_.visibility.push_back(1.0);
+  prev_tracked_robot_.visibility.push_back(0.0);
   // velocityはoptionalなので、ここでデフォルト値を設定しておく
   prev_tracked_robot_.vel.push_back(Vector2());
   prev_tracked_robot_.vel_angular.push_back(0.0);


### PR DESCRIPTION
ロボット座標の存在度を示す`visibility`のデフォルト値を、1.0から0.0に変更します。

これにより、CON-SAI起動直後の状態が、
「すべてのロボットが座標0, 0に存在する」　から
「ロボットが1台もいない」　に変わります。

game.py起動時の意図しないアタッカー入れ替わりを防ぐことができます。　が
その他、どのような影響が出るのかは未検証です。