### PR TITLE
NamedTargetを追加し、動的に変更できる任意座標を、行動の目標値として使用できる

### DIFF
--- a/consai_examples/CMakeLists.txt
+++ b/consai_examples/CMakeLists.txt
@@ -54,6 +54,7 @@ if(BUILD_TESTING)
 
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(test_role_assignment tests/test_role_assignment.py)
+  ament_add_pytest_test(test_robot_operator tests/test_robot_operator.py)
 endif()
 
 ament_package()

--- a/consai_examples/consai_examples/control.py
+++ b/consai_examples/consai_examples/control.py
@@ -364,10 +364,11 @@ def test_use_named_targets():
         # return State2D(x=clamp(x, -LIMIT_X, LIMIT_X), y=clamp(y, -LIMIT_Y, LIMIT_Y))
 
     def calc_pose_based_on_pose1(angle, offset_angle, pose1):
-        # pose1の周りを一周するposeを計算
+        # pose1の周りをN周するposeを計算
+        NUM_OF_ROTATIONS = 4
         LENGTH = 0.5
-        x = pose1.x + LENGTH * math.cos(4.0*(angle + offset_angle))
-        y = pose1.y + LENGTH * math.sin(4.0*(angle + offset_angle))
+        x = pose1.x + LENGTH * math.cos(NUM_OF_ROTATIONS*(angle + offset_angle))
+        y = pose1.y + LENGTH * math.sin(NUM_OF_ROTATIONS*(angle + offset_angle))
         return State2D(x=x, y=y)
 
     print("test_use_named_targets")
@@ -399,6 +400,10 @@ def test_use_named_targets():
     operator_node.move_to_named_target(2, "pose3", keep=True)
     operator_node.move_to_named_target(3, "pose4", keep=True)
 
+    # 別のロボットにはpose1に対してボールを蹴り続けてもらう
+    # NamedTargetはボールのキック対象としても選択可能である
+    operator_node.shoot_to_named_target(4, "pose1")
+
     MOTION_TIME = 20.0  # 動作の実行時間 seconds
     start_time = time.time()
     elapsed_time = 0.0
@@ -415,6 +420,13 @@ def test_use_named_targets():
         operator_node.set_named_target("pose3", pose3.x, pose3.y)
         operator_node.set_named_target("pose4", pose4.x, pose4.y)
         operator_node.publish_named_targets()
+
+    print('ロボットの動作停止！')
+    for i in range(5):
+        operator_node.stop(i)
+    # 動作完了まで待機
+    while operator_node.all_robots_are_free() is False:
+        pass
 
 def main():
     # 実行したい関数のコメントを外してください

--- a/consai_examples/consai_examples/decisions/substitute.py
+++ b/consai_examples/consai_examples/decisions/substitute.py
@@ -33,12 +33,14 @@ class SubstituteDecision(DecisionBase):
         # で交代できる
         # ただしボールがハーフウェーラインから2m以上離れている場合
         # https://robocup-ssl.github.io/ssl-rules/sslrules.html#_robot_substitution
+        target_name = "SUBSTITUTION_POS"
         pos_x = 0.0
         pos_y = -4.5 + -0.15
-        theta = 0.0
         if self._invert:
             pos_y *= -1.0
-        self._operator.move_to(robot_id, pos_x, pos_y, theta, keep=True)
+        self._operator.set_named_target(target_name, pos_x, pos_y)
+        self._operator.publish_named_targets()
+        self._operator.move_to_named_target(robot_id, target_name, keep=True)
 
     def stop(self, robot_id):
         if self._act_id != self.ACT_ID_STOP:

--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -64,6 +64,12 @@ def enable_update_attacker_by_ball_pos():
 
 def main():
     while rclpy.ok():
+
+        if referee.halt():
+            # 各decisionsがセットしたNamedTargetを消去する
+            operator.clear_named_targets()
+            operator.publish_named_targets()
+
         ball_state = observer.get_ball_state()
         ball_placement_state = observer.get_ball_placement_state(referee.placement_position())
         ball_zone_state = observer.get_ball_zone_state()

--- a/consai_examples/consai_examples/robot_operator.py
+++ b/consai_examples/consai_examples/robot_operator.py
@@ -94,8 +94,8 @@ class RobotOperator(Node):
         # チームの全てのロボットが行動を完了していたらtrue
         return all(self._robot_is_free)
 
-    def append_named_target(self, name, x, y, theta=0.0):
-        # 名前付きターゲットを追加する
+    def set_named_target(self, name, x, y, theta=0.0):
+        # 名前付きターゲットをセットする
         # すでに同じ名前のターゲットが用意されていても上書きする
         self._named_targets[name] = State2D(x=x, y=y, theta=theta)
 

--- a/consai_examples/consai_examples/robot_operator.py
+++ b/consai_examples/consai_examples/robot_operator.py
@@ -334,6 +334,10 @@ class RobotOperator(Node):
         # ボールの後ろに移動し、相手ゴールに向かってシュートする
         return self._act_to_ball(robot_id, self._xy_their_goal(), do_shoot=True)
 
+    def shoot_to_named_target(self, robot_id, name):
+        # ボールの後ろに移動し、名前付きターゲットに向かってシュートする
+        return self._act_to_ball(robot_id, self._xy_object_named_target(name), do_shoot=True)
+
     def shoot_to_their_goal_with_reflect(self, robot_id):
         # ボールの後ろに移動し、相手ゴールに向かってシュートする
         # ボールが自分に向かって転がってきた場合はリフレクトシュートする

--- a/consai_examples/consai_examples/robot_operator.py
+++ b/consai_examples/consai_examples/robot_operator.py
@@ -323,96 +323,37 @@ class RobotOperator(Node):
         return self._set_goal(robot_id, self._with_receive(self._line_goal(line, keep=True)))
 
     def pass_to(self, robot_id, x, y):
-        # ボールと指定位置(x, y)を結ぶ直線上で、ボールの後ろに移動し、
-        # 指定位置に向かってパスする
-        line = ConstraintLine()
-        line.p1.object.append(self._object_ball())
-        line.p2 = self._xy(x, y)
-        line.distance = -0.3
-        line.theta = self._theta_look_ball()
-        target = self._xy(x, y)
-        return self._set_goal(robot_id, self._with_kick(
-            self._line_goal(line, keep=True), target, kick_pass=True))
+        # ボールの後ろに移動し、指定位置に向かってパスする
+        return self._act_to_ball(robot_id, self._xy(x, y), do_pass=True)
 
     def shoot_to(self, robot_id, x, y):
-        # ボールと指定位置(x, y)を結ぶ直線上で、ボールの後ろに移動し、
-        # 指定位置に向かってシュートする
-        line = ConstraintLine()
-        line.p1.object.append(self._object_ball())
-        line.p2 = self._xy(x, y)
-        line.distance = -0.3
-        line.theta = self._theta_look_ball()
-        target = self._xy(x, y)
-        return self._set_goal(robot_id, self._with_kick(
-            self._line_goal(line, keep=True), target, kick_pass=False))
+        # ボールの後ろに移動し、指定位置に向かってシュートする
+        return self._act_to_ball(robot_id, self._xy(x, y), do_shoot=True)
 
     def shoot_to_their_goal(self, robot_id):
-        # ボールと相手ゴールを結ぶ直線上で、ボールの後ろに移動し、
-        # 相手ゴールに向かってシュートする
-        line = ConstraintLine()
-        line.p1.object.append(self._object_ball())
-        line.p2 = self._xy_their_goal()
-        line.distance = -0.3
-        line.theta = self._theta_look_ball()
-        target = self._xy_their_goal()
-        return self._set_goal(robot_id, self._with_receive(
-            self._with_kick(
-                self._line_goal(line, keep=True), target, kick_pass=False)))
+        # ボールの後ろに移動し、相手ゴールに向かってシュートする
+        return self._act_to_ball(robot_id, self._xy_their_goal(), do_shoot=True)
 
     def shoot_to_their_goal_with_reflect(self, robot_id):
-        # ボールと相手ゴールを結ぶ直線上で、ボールの後ろに移動し、
-        # 相手ゴールに向かってシュートする
-        line = ConstraintLine()
-        line.p1.object.append(self._object_ball())
-        line.p2 = self._xy_their_goal()
-        line.distance = -0.3
-        line.theta = self._theta_look_ball()
-        target = self._xy_their_goal()
-        return self._set_goal(robot_id, self._with_receive(
-            self._with_reflect_and_normal_kick(
-                self._line_goal(line, keep=True), target, kick_pass=False)))
+        # ボールの後ろに移動し、相手ゴールに向かってシュートする
+        # ボールが自分に向かって転がってきた場合はリフレクトシュートする
+        return self._act_to_ball(robot_id, self._xy_their_goal(), do_reflect_shoot=True)
 
     def shoot_to_their_corner(self, robot_id, target_is_top_corner=True, set_play=False):
-        # ボールと相手ゴールを結ぶ直線上で、ボールの後ろに移動し、
-        # 相手コーナーに向かってシュートする
+        # ボールの後ろに移動し、相手コーナーに向かってシュートする
         xy_target = self._xy_their_bottom_corner()
         if target_is_top_corner:
             xy_target = self._xy_their_top_corner()
 
-        line = ConstraintLine()
-        line.p1.object.append(self._object_ball())
-        line.p2 = xy_target
-        line.distance = -0.3
-        line.theta = self._theta_look_ball()
-        target = xy_target
-        return self._set_goal(robot_id, self._with_receive(
-            self._with_kick(
-                self._line_goal(line, keep=True), target, kick_pass=False, kick_setplay=set_play)))
+        return self._act_to_ball(robot_id, xy_target, do_shoot=True, as_setplay=set_play)
 
     def setplay_shoot_to_their_goal(self, robot_id):
-        # ボールと相手ゴールを結ぶ直線上で、ボールの後ろに移動し、
-        # 相手ゴールに向かってシュートする
-        line = ConstraintLine()
-        line.p1.object.append(self._object_ball())
-        line.p2 = self._xy_their_goal()
-        line.distance = -0.3
-        line.theta = self._theta_look_ball()
-        target = self._xy_their_goal()
-        return self._set_goal(robot_id, self._with_receive(
-            self._with_kick(
-                self._line_goal(line, keep=True), target, kick_pass=False, kick_setplay=True)))
+        # ボールの後ろに移動し、セットプレイのように慎重に、相手ゴールに向かってシュートする
+        return self._act_to_ball(robot_id, self._xy_their_goal(), do_shoot=True, as_setplay=True)
 
     def dribble_to(self, robot_id, x, y):
-        # ボールと指定位置(x, y)を結ぶ直線上で、ボールの後ろに移動し、
-        # 指定位置に向かってドリブルする
-        line = ConstraintLine()
-        line.p1.object.append(self._object_ball())
-        line.p2 = self._xy(x, y)
-        line.distance = -0.3
-        line.theta = self._theta_look_ball()
-        target = self._xy(x, y)
-        return self._set_goal(robot_id, self._with_dribble(
-            self._line_goal(line, keep=True), target))
+        # ボールの後ろに移動し、指定位置に向かってドリブルする
+        return self._act_to_ball(robot_id, self._xy(x, y), do_dribble=True)
 
     def receive_from(self, robot_id, x, y, offset, dynamic_receive=True):
         # ボールと指定位置(x, y)を結ぶ直線上で、指定位置からoffsetだけ後ろに下がり、
@@ -715,6 +656,40 @@ class RobotOperator(Node):
     def _with_receive(self, goal_msg):
         goal_msg.receive_ball = True
         return goal_msg
+
+    def _act_to_ball(self, robot_id, target_xy_object,
+                     do_shoot=False, do_pass=False, do_dribble=False,
+                     do_reflect_shoot=False,
+                     as_setplay=False):
+        # ボールとobjectを結ぶ直線上で、ボールの後ろに移動し、
+        # objectに向かってshoot/pass/dribbleする
+        if not any([do_shoot, do_pass, do_dribble, do_reflect_shoot]):
+            self.get_logger().warn('do_***のいずれかをセットしてください')
+            return
+
+        line = ConstraintLine()
+        line.p1.object.append(self._object_ball())
+        line.p2 = target_xy_object
+        line.distance = -0.3
+        line.theta = self._theta_look_ball()
+        target = target_xy_object
+
+        goal = None
+        if do_shoot:
+            goal = self._with_kick(
+                self._line_goal(line, keep=True), target, kick_pass=False, kick_setplay=as_setplay)
+        elif do_pass:
+            goal = self._with_kick(
+                self._line_goal(line, keep=True), target, kick_pass=True)
+        elif do_dribble:
+            goal = self._with_dribble(
+                self._line_goal(line, keep=True), target)
+        elif do_reflect_shoot:
+            goal = self._with_receive(
+                self._with_reflect_and_normal_kick(
+                    self._line_goal(line, keep=True), target, kick_pass=False))
+
+        self._set_goal(robot_id, goal)
 
     def _set_goal(self, robot_id, goal_msg):
         # アクションのゴールを設定する

--- a/consai_examples/consai_examples/robot_operator.py
+++ b/consai_examples/consai_examples/robot_operator.py
@@ -141,6 +141,20 @@ class RobotOperator(Node):
 
         return self._set_goal(robot_id, goal_msg)
 
+    def move_to_named_target(self, robot_id, name, keep=False):
+        # 指定したIDのロボットをnameで指定した名前付きターゲットへ移動させる
+
+        pose = ConstraintPose()
+
+        pose.xy = self._xy_object_named_target(name)
+        pose.theta = self._theta_object_named_target(name)
+
+        goal_msg = RobotControl.Goal()
+        goal_msg.pose.append(pose)
+        goal_msg.keep_control = keep
+
+        return self._set_goal(robot_id, goal_msg)
+
     def move_to_line(self, robot_id, p1_x, p1_y, p2_x, p2_y, distance, theta, keep=False):
         # 指定したIDのロボットを直線上へ移動させる
         line = ConstraintLine()
@@ -566,6 +580,26 @@ class RobotOperator(Node):
         xy.object.append(self._object_ball())
         return xy
 
+    def _object_named_target(self, name):
+        # ConstraintObjectのNamedTargetを返す
+        obj = ConstraintObject()
+        obj.type = ConstraintObject.NAMED_TARGET
+        obj.name = name
+        return obj
+
+    def _xy_object_named_target(self, name):
+        # NamedTargetを適用したConstraintXYを返す
+        xy = ConstraintXY()
+        xy.object.append(self._object_named_target(name))
+        return xy
+
+    def _theta_object_named_target(self, name):
+        # NamedTargetを適用したConstraintThetaを返す
+        theta = ConstraintTheta()
+        theta.object.append(self._object_named_target(name))
+        theta.param = ConstraintTheta.PARAM_THETA
+        return theta
+
     def _object_our_robot(self, robot_id):
         # ConstraintObjectの自チームのRobotを返す
         obj_robot = ConstraintObject()
@@ -706,7 +740,7 @@ class RobotOperator(Node):
         goal_handle = future.result()
 
         if not goal_handle.accepted:
-            self.get_logger().debug('Goal rejected')
+            self.get_logger().info('Goal rejected')
             self._robot_is_free[robot_id] = True
             return
 

--- a/consai_examples/consai_examples/robot_operator.py
+++ b/consai_examples/consai_examples/robot_operator.py
@@ -141,20 +141,6 @@ class RobotOperator(Node):
 
         return self._set_goal(robot_id, goal_msg)
 
-    def move_to_named_target(self, robot_id, name, keep=False):
-        # 指定したIDのロボットをnameで指定した名前付きターゲットへ移動させる
-
-        pose = ConstraintPose()
-
-        pose.xy = self._xy_object_named_target(name)
-        pose.theta = self._theta_object_named_target(name)
-
-        goal_msg = RobotControl.Goal()
-        goal_msg.pose.append(pose)
-        goal_msg.keep_control = keep
-
-        return self._set_goal(robot_id, goal_msg)
-
     def move_to_line(self, robot_id, p1_x, p1_y, p2_x, p2_y, distance, theta, keep=False):
         # 指定したIDのロボットを直線上へ移動させる
         line = ConstraintLine()
@@ -321,6 +307,37 @@ class RobotOperator(Node):
         line.distance = distance
         line.theta = self._theta_look_ball()
         return self._set_goal(robot_id, self._with_receive(self._line_goal(line, keep=True)))
+
+    def move_to_named_target(self, robot_id, name, keep=False):
+        # 指定したIDのロボットをnameで指定した名前付きターゲットへ移動させる
+        pose = ConstraintPose()
+        pose.xy = self._xy_object_named_target(name)
+        pose.theta = self._theta_object_named_target(name)
+
+        goal_msg = RobotControl.Goal()
+        goal_msg.pose.append(pose)
+        goal_msg.keep_control = keep
+
+        return self._set_goal(robot_id, goal_msg)
+
+    def move_to_named_target_with_reflect_pass_to_named_target(
+        self, robot_id, name_to_move, name_to_pass):
+        # 指定したIDのロボットをnameで指定した名前付きターゲットへ移動させる
+        # ボールが来たらリフレクトパスを実施する
+
+        pose = ConstraintPose()
+        pose.xy = self._xy_object_named_target(name_to_move)
+        pose.theta = self._theta_object_named_target(name_to_move)
+
+        goal_msg = RobotControl.Goal()
+        goal_msg.pose.append(pose)
+        goal_msg.keep_control = True
+
+        goal_msg = self._with_receive(
+            self._with_reflect_and_normal_kick(
+                goal_msg, self._xy_object_named_target(name_to_pass), kick_pass=True))
+
+        return self._set_goal(robot_id, goal_msg)
 
     def pass_to(self, robot_id, x, y):
         # ボールの後ろに移動し、指定位置に向かってパスする

--- a/consai_examples/tests/test_robot_operator.py
+++ b/consai_examples/tests/test_robot_operator.py
@@ -1,0 +1,105 @@
+from consai_examples.robot_operator import RobotOperator
+from consai_msgs.msg import NamedTargets
+import pytest
+import rclpy
+from rclpy.node import Node
+
+# NamedTargetsトピックをsubscribeするためのクラス
+class NamedTargetsSubscriber(Node):
+    def __init__(self):
+        super().__init__('subscriber')
+
+        self._sub_named_targets = self.create_subscription(
+            NamedTargets, 'named_targets', self._named_targets_callback, 1)
+        self.named_targets = NamedTargets()
+
+    def _named_targets_callback(self, msg):
+        self.named_targets = msg
+
+
+@pytest.fixture
+def rclpy_init_shutdown():
+    print("rclpy.init()")
+    rclpy.init()
+    yield
+    print("rclpy.shutdown()")
+    rclpy.shutdown()
+
+
+def test_セットしたnamed_targetsがpublishされること(rclpy_init_shutdown):
+    operator = RobotOperator()
+    subscriber = NamedTargetsSubscriber()
+
+    operator.append_named_target("test", x=1.2, y=3.4, theta=5.6)
+    operator.publish_named_targets()
+
+    # トピックをsubscribeするためspine_once()を実行
+    rclpy.spin_once(subscriber, timeout_sec=1.0)
+    assert len(subscriber.named_targets.name) == 1
+    assert subscriber.named_targets.name[0] == "test"
+    assert subscriber.named_targets.pose[0].x == 1.2
+    assert subscriber.named_targets.pose[0].y == 3.4
+    assert subscriber.named_targets.pose[0].theta == 5.6
+
+
+def test_複数のnamed_targetsをセットできること(rclpy_init_shutdown):
+    operator = RobotOperator()
+    subscriber = NamedTargetsSubscriber()
+
+    operator.append_named_target("test1", 0.0, 0.0)
+    operator.append_named_target("test2", 0.0, 0.0)
+    operator.append_named_target("test3", 0.0, 0.0)
+    operator.publish_named_targets()
+
+    # トピックをsubscribeするためspine_once()を実行
+    rclpy.spin_once(subscriber, timeout_sec=1.0)
+    assert len(subscriber.named_targets.name) == 3
+
+
+def test_同じ名前のnamed_targetsをセットした場合はデータを上書きすること(rclpy_init_shutdown):
+    operator = RobotOperator()
+    subscriber = NamedTargetsSubscriber()
+
+    operator.append_named_target("test", 0.0, 0.0)
+    operator.append_named_target("test", 1.2, 3.4)
+    operator.publish_named_targets()
+
+    # トピックをsubscribeするためspine_once()を実行
+    rclpy.spin_once(subscriber, timeout_sec=1.0)
+    assert len(subscriber.named_targets.name) == 1
+    assert subscriber.named_targets.name[0] == "test"
+    assert subscriber.named_targets.pose[0].x == 1.2
+    assert subscriber.named_targets.pose[0].y == 3.4
+
+
+def test_セットしたnamed_targetを個別に削除できること(rclpy_init_shutdown):
+    operator = RobotOperator()
+    subscriber = NamedTargetsSubscriber()
+
+    operator.append_named_target("test1", 0.0, 0.0)
+    operator.append_named_target("test2", 0.0, 0.0)
+    operator.append_named_target("test3", 0.0, 0.0)
+
+    operator.remove_named_target("test1")
+    # 存在しないnameを指定してもエラーが出ないこと
+    operator.remove_named_target("hoge")
+    operator.publish_named_targets()
+
+    # トピックをsubscribeするためspine_once()を実行
+    rclpy.spin_once(subscriber, timeout_sec=1.0)
+    assert len(subscriber.named_targets.name) == 2
+
+def test_セットしたnamed_targetsを一括削除できること(rclpy_init_shutdown):
+    operator = RobotOperator()
+    subscriber = NamedTargetsSubscriber()
+
+    operator.append_named_target("test1", 0.0, 0.0)
+    operator.append_named_target("test2", 0.0, 0.0)
+    operator.append_named_target("test3", 0.0, 0.0)
+
+    operator.clear_named_targets()
+    operator.publish_named_targets()
+
+    # トピックをsubscribeするためspine_once()を実行
+    rclpy.spin_once(subscriber, timeout_sec=1.0)
+    assert len(subscriber.named_targets.name) == 0

--- a/consai_examples/tests/test_robot_operator.py
+++ b/consai_examples/tests/test_robot_operator.py
@@ -30,7 +30,7 @@ def test_セットしたnamed_targetsがpublishされること(rclpy_init_shutdo
     operator = RobotOperator()
     subscriber = NamedTargetsSubscriber()
 
-    operator.append_named_target("test", x=1.2, y=3.4, theta=5.6)
+    operator.set_named_target("test", x=1.2, y=3.4, theta=5.6)
     operator.publish_named_targets()
 
     # トピックをsubscribeするためspine_once()を実行
@@ -46,9 +46,9 @@ def test_複数のnamed_targetsをセットできること(rclpy_init_shutdown):
     operator = RobotOperator()
     subscriber = NamedTargetsSubscriber()
 
-    operator.append_named_target("test1", 0.0, 0.0)
-    operator.append_named_target("test2", 0.0, 0.0)
-    operator.append_named_target("test3", 0.0, 0.0)
+    operator.set_named_target("test1", 0.0, 0.0)
+    operator.set_named_target("test2", 0.0, 0.0)
+    operator.set_named_target("test3", 0.0, 0.0)
     operator.publish_named_targets()
 
     # トピックをsubscribeするためspine_once()を実行
@@ -60,8 +60,8 @@ def test_同じ名前のnamed_targetsをセットした場合はデータを上�
     operator = RobotOperator()
     subscriber = NamedTargetsSubscriber()
 
-    operator.append_named_target("test", 0.0, 0.0)
-    operator.append_named_target("test", 1.2, 3.4)
+    operator.set_named_target("test", 0.0, 0.0)
+    operator.set_named_target("test", 1.2, 3.4)
     operator.publish_named_targets()
 
     # トピックをsubscribeするためspine_once()を実行
@@ -76,9 +76,9 @@ def test_セットしたnamed_targetを個別に削除できること(rclpy_init
     operator = RobotOperator()
     subscriber = NamedTargetsSubscriber()
 
-    operator.append_named_target("test1", 0.0, 0.0)
-    operator.append_named_target("test2", 0.0, 0.0)
-    operator.append_named_target("test3", 0.0, 0.0)
+    operator.set_named_target("test1", 0.0, 0.0)
+    operator.set_named_target("test2", 0.0, 0.0)
+    operator.set_named_target("test3", 0.0, 0.0)
 
     operator.remove_named_target("test1")
     # 存在しないnameを指定してもエラーが出ないこと
@@ -93,9 +93,9 @@ def test_セットしたnamed_targetsを一括削除できること(rclpy_init_s
     operator = RobotOperator()
     subscriber = NamedTargetsSubscriber()
 
-    operator.append_named_target("test1", 0.0, 0.0)
-    operator.append_named_target("test2", 0.0, 0.0)
-    operator.append_named_target("test3", 0.0, 0.0)
+    operator.set_named_target("test1", 0.0, 0.0)
+    operator.set_named_target("test2", 0.0, 0.0)
+    operator.set_named_target("test3", 0.0, 0.0)
 
     operator.clear_named_targets()
     operator.publish_named_targets()

--- a/consai_msgs/CMakeLists.txt
+++ b/consai_msgs/CMakeLists.txt
@@ -27,6 +27,7 @@ set(msg_files
   "msg/ConstraintTheta.msg"
   "msg/ConstraintXY.msg"
   "msg/GoalPose.msg"
+  "msg/NamedTargets.msg"
   "msg/ParsedReferee.msg"
   "msg/State2D.msg"
 )

--- a/consai_msgs/msg/ConstraintObject.msg
+++ b/consai_msgs/msg/ConstraintObject.msg
@@ -4,8 +4,10 @@ uint32 UNKNOWN = 0
 uint32 BALL = 1
 uint32 BLUE_ROBOT = 2
 uint32 YELLOW_ROBOT = 3
+uint32 NAMED_TARGET = 4
 
 uint32 ROBOT_ID_UNKNOWN = 99
 
 uint32 type 0
 uint32 robot_id 99
+string name

--- a/consai_msgs/msg/NamedTargets.msg
+++ b/consai_msgs/msg/NamedTargets.msg
@@ -1,0 +1,5 @@
+# ConstraintObjectをもとに参照される名前付きターゲット
+# nameとposeはペアとなり、同じインデックスで参照されること
+
+string[] name
+State2D[] pose

--- a/consai_robot_controller/include/consai_robot_controller/controller_component.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/controller_component.hpp
@@ -23,6 +23,7 @@
 #include "consai_frootspi_msgs/msg/robot_command.hpp"
 #include "consai_msgs/action/robot_control.hpp"
 #include "consai_msgs/msg/goal_pose.hpp"
+#include "consai_msgs/msg/named_targets.hpp"
 #include "consai_msgs/msg/parsed_referee.hpp"
 #include "consai_msgs/msg/state2_d.hpp"
 #include "consai_robot_controller/field_info_parser.hpp"
@@ -37,6 +38,7 @@
 namespace consai_robot_controller
 {
 using GoalPose = consai_msgs::msg::GoalPose;
+using NamedTargets = consai_msgs::msg::NamedTargets;
 using State = consai_msgs::msg::State2D;
 using RobotCommand = consai_frootspi_msgs::msg::RobotCommand;
 using RobotControl = consai_msgs::action::RobotControl;
@@ -63,6 +65,7 @@ private:
   void callback_geometry(const GeometryData::SharedPtr msg);
   void callback_referee(const Referee::SharedPtr msg);
   void callback_parsed_referee(const ParsedReferee::SharedPtr msg);
+  void callback_named_targets(const NamedTargets::SharedPtr msg);
   bool update_pid_gain_from_param(
     const rclcpp::Parameter & param,
     const std::string & prefix,
@@ -102,6 +105,7 @@ private:
   consai_robot_controller::FieldInfoParser parser_;
   rclcpp::Subscription<TrackedFrame>::SharedPtr sub_detection_tracked_;
   rclcpp::Subscription<GeometryData>::SharedPtr sub_geometry_;
+  rclcpp::Subscription<NamedTargets>::SharedPtr sub_named_targets_;
   rclcpp::Subscription<Referee>::SharedPtr sub_referee_;
   rclcpp::Subscription<ParsedReferee>::SharedPtr sub_parsed_referee_;
   bool team_is_yellow_;

--- a/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
@@ -15,6 +15,7 @@
 #ifndef CONSAI_ROBOT_CONTROLLER__FIELD_INFO_PARSER_HPP_
 #define CONSAI_ROBOT_CONTROLLER__FIELD_INFO_PARSER_HPP_
 
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -24,6 +25,7 @@
 #include "consai_msgs/msg/constraint_pose.hpp"
 #include "consai_msgs/msg/constraint_theta.hpp"
 #include "consai_msgs/msg/constraint_xy.hpp"
+#include "consai_msgs/msg/named_targets.hpp"
 #include "consai_msgs/msg/parsed_referee.hpp"
 #include "consai_msgs/msg/state2_d.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -42,6 +44,7 @@ using ConstraintObject = consai_msgs::msg::ConstraintObject;
 using ConstraintPose = consai_msgs::msg::ConstraintPose;
 using ConstraintTheta = consai_msgs::msg::ConstraintTheta;
 using ConstraintXY = consai_msgs::msg::ConstraintXY;
+using NamedTargets = consai_msgs::msg::NamedTargets;
 using State = consai_msgs::msg::State2D;
 using GeometryData = robocup_ssl_msgs::msg::GeometryData;
 using ParsedReferee = consai_msgs::msg::ParsedReferee;
@@ -60,6 +63,7 @@ public:
   void set_geometry(const GeometryData::SharedPtr geometry);
   void set_referee(const Referee::SharedPtr referee);
   void set_parsed_referee(const ParsedReferee::SharedPtr parsed_referee);
+  void set_named_targets(const NamedTargets::SharedPtr msg);
   bool extract_robot(
     const unsigned int robot_id, const bool team_is_yellow,
     TrackedRobot & my_robot) const;
@@ -117,6 +121,7 @@ private:
   std::shared_ptr<ParsedReferee> parsed_referee_;
   bool invert_;
   bool team_is_yellow_;
+  std::map<std::string, State> named_targets_;
 };
 
 }  // namespace consai_robot_controller

--- a/consai_robot_controller/src/controller_component.cpp
+++ b/consai_robot_controller/src/controller_component.cpp
@@ -158,6 +158,8 @@ Controller::Controller(const rclcpp::NodeOptions & options)
     "referee", 10, std::bind(&Controller::callback_referee, this, _1));
   sub_parsed_referee_ = create_subscription<ParsedReferee>(
     "parsed_referee", 10, std::bind(&Controller::callback_parsed_referee, this, _1));
+  sub_named_targets_ = create_subscription<NamedTargets>(
+    "named_targets", 10, std::bind(&Controller::callback_named_targets, this, _1));
 
   auto param_change_callback =
     [this](std::vector<rclcpp::Parameter> parameters) {
@@ -356,6 +358,11 @@ void Controller::callback_referee(const Referee::SharedPtr msg)
 void Controller::callback_parsed_referee(const ParsedReferee::SharedPtr msg)
 {
   parser_.set_parsed_referee(msg);
+}
+
+void Controller::callback_named_targets(const NamedTargets::SharedPtr msg)
+{
+  parser_.set_named_targets(msg);
 }
 
 bool Controller::update_pid_gain_from_param(

--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -131,15 +131,11 @@ bool FieldInfoParser::parse_goal(
   if (goal->pose.size() > 0) {
     if (parse_constraint_pose(goal->pose[0], target_pose)) {
       parse_succeeded = true;
-    } else {
-      std::cout << "parse_constraint_pose failed" << std::endl;
     }
   }
   if (goal->line.size() > 0) {
     if (parse_constraint_line(goal->line[0], target_pose)) {
       parse_succeeded = true;
-    } else {
-      std::cout << "parse_constraint_line failed" << std::endl;
     }
   }
 
@@ -259,7 +255,6 @@ bool FieldInfoParser::parse_constraint_pose(const ConstraintPose & pose, State &
 {
   double parsed_x, parsed_y;
   if (!parse_constraint_xy(pose.xy, parsed_x, parsed_y)) {
-    std::cout << "parse_constraint_xy failed" << std::endl;
     return false;
   }
   parsed_x += pose.offset.x;
@@ -267,7 +262,6 @@ bool FieldInfoParser::parse_constraint_pose(const ConstraintPose & pose, State &
 
   double parsed_theta;
   if (!parse_constraint_theta(pose.theta, parsed_x, parsed_y, parsed_theta)) {
-    std::cout << "parse_constraint_theta failed" << std::endl;
     return false;
   }
 

--- a/consai_visualizer/src/consai_visualizer/visualizer.py
+++ b/consai_visualizer/src/consai_visualizer/visualizer.py
@@ -20,6 +20,7 @@ import os
 
 from ament_index_python.resources import get_resource
 from consai_msgs.msg import GoalPose
+from consai_msgs.msg import NamedTargets
 from consai_visualizer.field_widget import FieldWidget
 import consai_visualizer.referee_parser as ref_parser
 from python_qt_binding import loadUi
@@ -74,6 +75,9 @@ class Visualizer(Plugin):
         self._sub_referee = self._node.create_subscription(
             Referee, 'referee',
             self._callback_referee, 10)
+        self._sub_named_targets = self._node.create_subscription(
+            NamedTargets, 'named_targets',
+            self._widget.field_widget.set_named_targets, 10)
 
         self._sub_goal_pose = []
         for i in range(16):


### PR DESCRIPTION
robot_operatorとコントローラ間で使用するメッセージ（`ConstraintObject`）に、名前付きターゲット（`NamedTargets`）を追加します。

NamedTargetsは`named_targets`トピックとしてpub/subします。
NamedTargetsは、ボールやロボットと同じようなオブジェクトとしてコントローラが参照できます。

# 変更点

## consai_msgs

- NamedTargets型を追加します
- ConstraintObjectのtypeに`NAME_TARGET`を追加します。

## consai_visualizer

- NamedTargetを描画します

![image](https://user-images.githubusercontent.com/18494952/233831894-95f22488-cf09-4dd0-83da-c7aa8a66f0d9.png)

## consai_robot_controller

- `named_targets`トピックをsubscribeします
- `ConstraintObject`のtype`NAME_TARGET`に対応します

## consai_examples

### robot_operator.py

- NamedTargetを扱うための、set, remove, clear, publish関数を追加します
  - これらは`test_robot_operator.py`でユニットテストしています
- NamedTargetを使用した関数`move_to_named_target`と` move_to_named_target_with_reflect_pass_to_named_target`を追加します
  - **これらはあくまで一例です**
  - 今後の開発で、必要に応じて便利な関数を追加してください（例：NamedTargetに向かってシュートする関数）

### control.py

- NamedTargetの使用例として、`test_use_named_targets`と`test_star_pass`を追加します
  - `test_star_pass`は5台のロボットが互いにパスする関数ですが、**パスできません**
  - consai_robto_controllerでのパス威力計算に改善が必要です（今はパスが固定値なので）

### game.py

- NamedTargetを使う骨組みを追加します
- NamedTargetの使用例として、SUBSTITUTEを改変しています