### PR TITLE
フィールドにいるロボットの抽出とボールを保持しているロボットから見た味方、相手ロボットのIDをリストに格納している部分の関数化

### DIFF
--- a/consai_examples/consai_examples/control.py
+++ b/consai_examples/consai_examples/control.py
@@ -326,23 +326,6 @@ def test_refelect_shoot_four_robots(id1, id2, id3, id4):
     while operator_node.all_robots_are_free() is False:
         pass
 
-def find_passable_robots(robot_id_has_ball, select_forward_between):
-    # パスができる味方ロボットを探す
-    # select_forward_betweenは
-    # 0であれば前方の相手ロボットすべてを対象にする
-    # 1であればパサーとレシーバー候補となる味方ロボットの間にいる相手ロボットを対象にする
-    while rclpy.ok():
-        our_robots_pos = observer_node.get_our_robots_pos()
-        their_robots_pos = observer_node.get_their_robots_pos()
-        our_robots_vel = observer_node.get_our_robots_vel()
-        their_robots_vel = observer_node.get_their_robots_vel()
-
-        if len(our_robots_pos) > 0:
-            break
-
-    robots_to_pass = operator_node.search_for_pass_cource(robot_id_has_ball, our_robots_pos, our_robots_vel, their_robots_pos, their_robots_vel, select_forward_between)
-    print(robots_to_pass)
-
 def test_use_named_targets():
     # 名前付きターゲットを用いてロボットを動かす
     # 名前付きターゲットはnamed_targetsトピックに含まれるpose情報である
@@ -499,7 +482,6 @@ def main():
     # test_defend_goal_on_line(-1.0, 1.0, -1.0, -1.0)
     # test_reflect_shoot(0, 0, 0)
     # test_refelect_shoot_four_robots(0, 1, 2, 3)
-    # find_passable_robots(4, 1)
     # test_use_named_targets()
     test_star_pass()
 

--- a/consai_examples/consai_examples/field_observer.py
+++ b/consai_examples/consai_examples/field_observer.py
@@ -726,28 +726,24 @@ class FieldObserver(Node):
 
         return receive_dist_our_robot
 
-    def _get_our_robots_in_field(self, our_robots_pos):
-        our_robots_in_field = [robot_id for robot_id in range(len(our_robots_pos)) if our_robots_pos[robot_id] != "None"]
-        return our_robots_in_field
-
-    def _get_their_robots_in_field(self, their_robots_pos):
-        # フィールド上にいる相手ロボットのIDのみリストに格納する
-        their_robots_in_field = [robot_id for robot_id in range(len(their_robots_pos)) if their_robots_pos[robot_id] != "None"]
-        return their_robots_in_field
+    def _get_robots_in_field(self, robots_pos):
+        # フィールド上にいるロボットのIDのみリスト化
+        robots_in_field = [robot_id for robot_id in range(len(robots_pos)) if robots_pos[robot_id] != "None"]
+        return robots_in_field
 
     def _forward_our_robots_id(self, robot_id_has_ball, our_robots_pos, our_robots_vel, robot_r, dt):
-        # フィールド上にいる味方ロボットのIDのみリストに格納する
-        our_robots_in_field = self._get_our_robots_in_field(our_robots_pos)
-        # パサーよりも前にいるロボットIDをリストにまとめる
-        # 味方ロボットに対して
+        # フィールド上にいる味方ロボットのIDのみリスト化
+        our_robots_in_field = self._get_robots_in_field(our_robots_pos)
+        # パサーよりも前にいる味方ロボットのIDをリスト化
         forward_our_robots_id = [robot_id for robot_id in our_robots_in_field 
                                 if robot_id != robot_id_has_ball and our_robots_pos[robot_id_has_ball][0] < our_robots_pos[robot_id][0] + (abs(our_robots_vel[robot_id][0]) * dt + robot_r) * 
                                 our_robots_vel[robot_id][0] / math.sqrt(our_robots_vel[robot_id][0] ** 2 + our_robots_vel[robot_id][1] ** 2)]
         return forward_our_robots_id
 
     def _forward_their_robots_id(self, robot_id_has_ball, our_robots_pos, their_robots_pos, their_robots_vel, robot_r, dt):
-        their_robots_in_field = self._get_their_robots_in_field(their_robots_pos)
-        # 相手ロボットに対してパサーよりも前にいるロボットIDをリストにまとめる
+        # フィールド上にいる相手ロボットのidのみリスト化
+        their_robots_in_field = self._get_robots_in_field(their_robots_pos)
+        # パサーよりも前にいる相手ロボットのIDをリスト化
         forward_their_robots_id = [robot_id for robot_id in their_robots_in_field 
                                   if our_robots_pos[robot_id_has_ball][0] < their_robots_pos[robot_id][0] + (abs(their_robots_vel[robot_id][0]) * dt + robot_r) * 
                                   their_robots_vel[robot_id][0] / math.sqrt(their_robots_vel[robot_id][0] ** 2 + their_robots_vel[robot_id][1] ** 2)]

--- a/consai_examples/consai_examples/field_observer.py
+++ b/consai_examples/consai_examples/field_observer.py
@@ -638,18 +638,10 @@ class FieldObserver(Node):
         if type(our_robots_vel[0]) is not list:
             return []
 
-        # フィールド上にいるロボットのIDのみリストに格納する
-        our_robots_in_field = [robot_id for robot_id in range(len(our_robots_pos)) if our_robots_pos[robot_id] != "None"]
-        their_robots_in_field = [robot_id for robot_id in range(len(their_robots_pos)) if their_robots_pos[robot_id] != "None"]
-
         # パサーよりも前にいる味方ロボットIDをリストにまとめる
-        forward_our_robots_id = [robot_id for robot_id in our_robots_in_field 
-                                if robot_id != my_robot_id and our_robots_pos[my_robot_id][0] < our_robots_pos[robot_id][0] + (abs(our_robots_vel[robot_id][0]) * dt + robot_r) * 
-                                our_robots_vel[robot_id][0] / math.sqrt(our_robots_vel[robot_id][0] ** 2 + our_robots_vel[robot_id][1] ** 2)]
+        forward_our_robots_id = self._forward_our_robots_id(my_robot_id, our_robots_pos, our_robots_vel, robot_r, dt)
         # パサーよりも前にいる敵ロボットIDをリストにまとめる
-        forward_their_robots_id = [robot_id for robot_id in their_robots_in_field 
-                                  if our_robots_pos[my_robot_id][0] < their_robots_pos[robot_id][0] + (abs(their_robots_vel[robot_id][0]) * dt + robot_r) * 
-                                  their_robots_vel[robot_id][0] / math.sqrt(their_robots_vel[robot_id][0] ** 2 + their_robots_vel[robot_id][1] ** 2)]
+        forward_their_robots_id = self._forward_their_robots_id(my_robot_id, our_robots_pos, their_robots_pos, their_robots_vel, robot_r, dt)
 
         # パサーよりも前にいるロボットがいなければ空のリストを返す
         if len(forward_our_robots_id) == 0:
@@ -734,3 +726,29 @@ class FieldObserver(Node):
 
         return receive_dist_our_robot
 
+    def _get_our_robots_in_field(self, our_robots_pos):
+        our_robots_in_field = [robot_id for robot_id in range(len(our_robots_pos)) if our_robots_pos[robot_id] != "None"]
+        return our_robots_in_field
+
+    def _get_their_robots_in_field(self, their_robots_pos):
+        # フィールド上にいる相手ロボットのIDのみリストに格納する
+        their_robots_in_field = [robot_id for robot_id in range(len(their_robots_pos)) if their_robots_pos[robot_id] != "None"]
+        return their_robots_in_field
+
+    def _forward_our_robots_id(self, robot_id_has_ball, our_robots_pos, our_robots_vel, robot_r, dt):
+        # フィールド上にいる味方ロボットのIDのみリストに格納する
+        our_robots_in_field = self._get_our_robots_in_field(our_robots_pos)
+        # パサーよりも前にいるロボットIDをリストにまとめる
+        # 味方ロボットに対して
+        forward_our_robots_id = [robot_id for robot_id in our_robots_in_field 
+                                if robot_id != robot_id_has_ball and our_robots_pos[robot_id_has_ball][0] < our_robots_pos[robot_id][0] + (abs(our_robots_vel[robot_id][0]) * dt + robot_r) * 
+                                our_robots_vel[robot_id][0] / math.sqrt(our_robots_vel[robot_id][0] ** 2 + our_robots_vel[robot_id][1] ** 2)]
+        return forward_our_robots_id
+
+    def _forward_their_robots_id(self, robot_id_has_ball, our_robots_pos, their_robots_pos, their_robots_vel, robot_r, dt):
+        their_robots_in_field = self._get_their_robots_in_field(their_robots_pos)
+        # 相手ロボットに対してパサーよりも前にいるロボットIDをリストにまとめる
+        forward_their_robots_id = [robot_id for robot_id in their_robots_in_field 
+                                  if our_robots_pos[robot_id_has_ball][0] < their_robots_pos[robot_id][0] + (abs(their_robots_vel[robot_id][0]) * dt + robot_r) * 
+                                  their_robots_vel[robot_id][0] / math.sqrt(their_robots_vel[robot_id][0] ** 2 + their_robots_vel[robot_id][1] ** 2)]
+        return forward_their_robots_id


### PR DESCRIPTION
- field_observer.py
	- パス関数で使っているフィールドにいるロボットの抽出とボールを保持しているロボットから見た味方、相手ロボットのIDをリストに格納している部分を関数化
	
- control.py
	- パス関数移植前の動作確認用コードの削除