### PR TITLE
Transクラスの実装とテストの作成

### DIFF
--- a/consai_examples/CMakeLists.txt
+++ b/consai_examples/CMakeLists.txt
@@ -55,7 +55,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(test_role_assignment tests/test_role_assignment.py)
   ament_add_pytest_test(test_robot_operator tests/test_robot_operator.py)
-  ament_add_pytest_test(test_geometory_tools tests/test_geometory_tools.py)
+  ament_add_pytest_test(test_geometry_tools tests/test_geometry_tools.py)
 endif()
 
 ament_package()

--- a/consai_examples/CMakeLists.txt
+++ b/consai_examples/CMakeLists.txt
@@ -55,6 +55,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(test_role_assignment tests/test_role_assignment.py)
   ament_add_pytest_test(test_robot_operator tests/test_robot_operator.py)
+  ament_add_pytest_test(test_robot_operator tests/test_geometory_tools.py)
 endif()
 
 ament_package()

--- a/consai_examples/CMakeLists.txt
+++ b/consai_examples/CMakeLists.txt
@@ -55,7 +55,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
   ament_add_pytest_test(test_role_assignment tests/test_role_assignment.py)
   ament_add_pytest_test(test_robot_operator tests/test_robot_operator.py)
-  ament_add_pytest_test(test_robot_operator tests/test_geometory_tools.py)
+  ament_add_pytest_test(test_geometory_tools tests/test_geometory_tools.py)
 endif()
 
 ament_package()

--- a/consai_examples/consai_examples/geometry_tools.py
+++ b/consai_examples/consai_examples/geometry_tools.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+# coding: UTF-8
+
+# Copyright 2021 Roots
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import cmath
+import numpy
+
+def get_distance(pose1, pose2):
+    # 2点間の距離を取る関数
+
+    diff_pose_x = pose1[0] - pose2[0]
+    diff_pose_y = pose1[1] - pose2[1]
+
+    return math.hypot(diff_pose_x, diff_pose_y)
+
+def get_angle(from_pose, to_pose):
+    # ワールド座標系でfrom_poseからto_poseを結ぶ直線の角度を得る
+
+    diff_pose_x = to_pose[0] - from_pose[0]
+    diff_pose_y = to_pose[1] - from_pose[1]
+
+    return math.atan2(diff_pose_y, diff_pose_x)
+
+def angle_normalize(angle):
+    # 角度をpi  ~ -piの範囲に変換する関数
+    while angle > math.pi:
+        angle -= 2*math.pi
+
+    while angle < -math.pi:
+        angle += 2*math.pi
+
+    return angle
+
+class Trans():
+    # 座標系を移動、回転するクラス
+    def __init__(self, center , theta):
+        normalized_theta = angle_normalize(theta)
+        self._c_center = center[0] + center[1] * 1.0j
+        self._c_rotate = cmath.rect(1.0, normalized_theta) 
+        self._c_angle = normalized_theta
+
+    def transform(self, pose):
+        c_point = pose[0] + pose[1] * 1.0j
+        c_output = (c_point - self._c_center) * numpy.conj(self._c_rotate)
+
+        return [c_output.real, c_output.imag]
+
+    def inverted_transform(self, pose):
+        c_point = pose[0] + pose[1] * 1.0j
+        c_output = c_point * self._c_rotate + self._c_center
+
+        return [c_output.real, c_output.imag]
+
+    def transform_angle(self, angle):
+        return angle_normalize(angle - self._c_angle)
+
+    def inverted_transform_angle(self, angle):
+        return angle_normalize(angle + self._c_angle)
+

--- a/consai_examples/tests/test_geometry_tools.py
+++ b/consai_examples/tests/test_geometry_tools.py
@@ -1,0 +1,38 @@
+import pytest
+import math
+import consai_examples.geometry_tools as tool
+
+def test_trans_class():
+    
+    trans = tool.Trans([0, 0], float(math.pi / 2))
+    p_trans = trans.transform([0, 1]) 
+    assert math.isclose(p_trans[0], 1, abs_tol=0.01)
+    assert math.isclose(p_trans[1], 0, abs_tol=0.01)
+
+    p = trans.inverted_transform(p_trans) 
+    assert math.isclose(p[0], 0, abs_tol=0.01)
+    assert math.isclose(p[1], 1, abs_tol=0.01)
+
+    trans = tool.Trans([0, 0], float(math.pi / 4))
+    p_trans = trans.transform([0, 1]) 
+    assert math.isclose(p_trans[0], 0.7071, abs_tol=0.01)
+    assert math.isclose(p_trans[1], 0.7071, abs_tol=0.01)
+
+    p = trans.inverted_transform(p_trans) 
+    assert math.isclose(p[0], 0, abs_tol=0.01)
+    assert math.isclose(p[1], 1, abs_tol=0.01)
+
+def test_get_distance():
+    distance = tool.get_distance([0, 0], [1, 1])
+    assert math.isclose(distance, 1.414, abs_tol=0.01)
+    
+    distance = tool.get_distance([-1, 2], [1, 1])
+    assert math.isclose(distance, 2.236, abs_tol=0.01)
+
+def test_get_angle():
+    angle = tool.get_angle([0, 0], [1, 1])
+    assert math.isclose(angle, float(math.pi / 4), abs_tol=0.01)
+    
+    angle = tool.get_angle([0, 0], [-1, -1])
+    assert math.isclose(angle, float(-math.pi * 3 / 4), abs_tol=0.01)
+

--- a/consai_examples/tests/test_geometry_tools.py
+++ b/consai_examples/tests/test_geometry_tools.py
@@ -36,3 +36,16 @@ def test_get_angle():
     angle = tool.get_angle([0, 0], [-1, -1])
     assert math.isclose(angle, float(-math.pi * 3 / 4), abs_tol=0.01)
 
+def test_angle_normalize():
+    angle = tool.angle_normalize(math.pi / 2)
+    assert math.isclose(angle, float(math.pi / 2), abs_tol=0.01)
+
+    angle = tool.angle_normalize(-math.pi / 2)
+    assert math.isclose(angle, float(-math.pi / 2), abs_tol=0.01)
+
+    angle = tool.angle_normalize(3 * math.pi)
+    assert math.isclose(angle, float(math.pi), abs_tol=0.01)
+    
+    angle = tool.angle_normalize(-3 * math.pi)
+    assert math.isclose(angle, float(-math.pi), abs_tol=0.01)
+


### PR DESCRIPTION
consai2に実装されていたtransクラス（といくつかの関数）を移植
- geometry_tools.py
  - consai2のtool.pyの移植版
  - consai2ではPose2()を座標に使っていたが今回はリストで実装
- test_geometry_tools.py
  - geometry_tools.pyのテストコード