### PR TITLE
ボールの場外判定を前後左右それぞれ判定するようにした

### DIFF
--- a/consai_examples/consai_examples/decisions/attacker.py
+++ b/consai_examples/consai_examples/decisions/attacker.py
@@ -29,14 +29,14 @@ class AttackerDecision(DecisionBase):
         ID_IN_THEIR_DEFENSE = self.ACT_ID_STOP + 2
 
         # ボールが自分ディフェンスエリアにあるときは、ボールと同じ軸上に移動する
-        if self._ball_state == FieldObserver.BALL_IS_IN_OUR_DEFENSE_AREA:
+        if self._ball_state == FieldObserver.BALL_IS_IN_OUR_DEFENSE_AREA or self._ball_state == FieldObserver.BALL_IS_OUTSIDE_BACK_X:
             if self._act_id != ID_IN_OUR_DEFENSE:
                 self._operator.move_to_ball_y(robot_id, -3.0)
                 self._act_id = ID_IN_OUR_DEFENSE
             return
 
         # ボールが相手ディフェンスエリアにあるときは、ボールと同じ軸上に移動する
-        if self._ball_state == FieldObserver.BALL_IS_IN_THEIR_DEFENSE_AREA:
+        if self._ball_state == FieldObserver.BALL_IS_IN_THEIR_DEFENSE_AREA or self._ball_state == FieldObserver.BALL_IS_OUTSIDE_FRONT_X:
             if self._act_id != ID_IN_THEIR_DEFENSE:
                 self._operator.move_to_ball_y(robot_id, 3.0)
                 self._act_id = ID_IN_THEIR_DEFENSE
@@ -53,14 +53,14 @@ class AttackerDecision(DecisionBase):
         ID_IN_THEIR_DEFENSE = self.ACT_ID_INPLAY + 2
 
         # ボールが自分ディフェンスエリアにあるときは、ボールと同じ軸上に移動する
-        if self._ball_state == FieldObserver.BALL_IS_IN_OUR_DEFENSE_AREA:
+        if self._ball_state == FieldObserver.BALL_IS_IN_OUR_DEFENSE_AREA or self._ball_state == FieldObserver.BALL_IS_OUTSIDE_BACK_X:
             if self._act_id != ID_IN_OUR_DEFENSE:
                 self._operator.move_to_ball_y(robot_id, -3.0)
                 self._act_id = ID_IN_OUR_DEFENSE
             return
 
         # ボールが相手ディフェンスエリアにあるときは、ボールと同じ軸上に移動する
-        if self._ball_state == FieldObserver.BALL_IS_IN_THEIR_DEFENSE_AREA:
+        if self._ball_state == FieldObserver.BALL_IS_IN_THEIR_DEFENSE_AREA or self._ball_state == FieldObserver.BALL_IS_OUTSIDE_FRONT_X:
             if self._act_id != ID_IN_THEIR_DEFENSE:
                 self._operator.move_to_ball_y(robot_id, 3.0)
                 self._act_id = ID_IN_THEIR_DEFENSE

--- a/consai_examples/consai_examples/field_observer.py
+++ b/consai_examples/consai_examples/field_observer.py
@@ -29,11 +29,14 @@ from robocup_ssl_msgs.msg import TrackedRobot
 # ロボットに一番近いロボットを判定する
 class FieldObserver(Node):
     BALL_NONE = 0
-    BALL_IS_OUTSIDE = 1
-    BALL_IS_IN_OUR_DEFENSE_AREA = 2
-    BALL_IS_IN_OUR_SIDE = 3
-    BALL_IS_IN_THEIR_SIDE = 4
-    BALL_IS_IN_THEIR_DEFENSE_AREA = 5
+    BALL_IS_OUTSIDE_FRONT_X = 1
+    BALL_IS_OUTSIDE_BACK_X = 2
+    BALL_IS_OUTSIDE_RIGHT_Y = 3
+    BALL_IS_OUTSIDE_LEFT_Y = 4
+    BALL_IS_IN_OUR_DEFENSE_AREA = 5
+    BALL_IS_IN_OUR_SIDE = 6
+    BALL_IS_IN_THEIR_SIDE = 7
+    BALL_IS_IN_THEIR_DEFENSE_AREA = 8
 
     BALL_PLACEMENT_NONE = 0
     BALL_PLACEMENT_FAR_FROM_TARGET = 1
@@ -195,9 +198,20 @@ class FieldObserver(Node):
         return self.their_robots_vel_angle
 
     def _update_ball_state(self, ball):
-        # フィールド場外判定
-        if self._check_is_ball_outside(ball.pos):
-            self._ball_state = self.BALL_IS_OUTSIDE
+        # フィールド場外判定(Goal-to-Goal方向)
+        if self._check_is_ball_outside_front_x(ball.pos):
+            self._ball_state = self.BALL_IS_OUTSIDE_FRONT_X
+            return
+        if self._check_is_ball_outside_back_x(ball.pos):
+            self._ball_state = self.BALL_IS_OUTSIDE_BACK_X
+            return
+        
+        # フィールド場外判定(Halfway方向)
+        if self._check_is_ball_outside_right_y(ball.pos):
+            self._ball_state = self.BALL_IS_OUTSIDE_RIGHT_Y
+            return
+        if self._check_is_ball_outside_left_y(ball.pos):
+            self._ball_state = self.BALL_IS_OUTSIDE_LEFT_Y
             return
 
         # 自チームディフェンスエリア侵入判定
@@ -218,15 +232,51 @@ class FieldObserver(Node):
         # 条件に入らなければ、相手チームエリアに侵入したと判定
         self._ball_state = self.BALL_IS_IN_THEIR_SIDE
 
-    def _check_is_ball_outside(self, ball_pos):
+    def _check_is_ball_outside_front_x(self, ball_pos):
         # ボールがフィールド外に出たか判定
+        # xはGoal-to-Goalの方向
+        # 相手ゴール方向
         threshold_x = self._field_half_x
-        threshold_y = self._field_half_y
-        if self.ball_is_outside():
+        if self.ball_is_outside_front_x():
             threshold_x -= self.THRESHOLD_MARGIN
+
+        if ball_pos.x > threshold_x:
+            return True
+        return False
+
+    def _check_is_ball_outside_back_x(self, ball_pos):
+        # ボールがフィールド外に出たか判定
+        # xはGoal-to-Goalの方向
+        # 自ゴール方向
+        threshold_x = self._field_half_x
+        if self.ball_is_outside_back_x():
+            threshold_x += self.THRESHOLD_MARGIN
+
+        if ball_pos.x < -threshold_x:
+            return True
+        return False
+    
+    def _check_is_ball_outside_right_y(self, ball_pos):
+        # ボールがフィールド外に出たか判定
+        # yはHalfwayの方向
+        # 相手ゴールに対して右側
+        threshold_y = self._field_half_y
+        if self.ball_is_outside_right_y():
             threshold_y -= self.THRESHOLD_MARGIN
 
-        if math.fabs(ball_pos.x) > threshold_x or math.fabs(ball_pos.y) > threshold_y:
+        if ball_pos.y > threshold_y:
+            return True
+        return False
+    
+    def _check_is_ball_outside_left_y(self, ball_pos):
+        # ボールがフィールド外に出たか判定
+        # yはHalfwayの方向
+        # 相手ゴールに対して左側
+        threshold_y = self._field_half_y
+        if self.ball_is_outside_left_y():
+            threshold_y += self.THRESHOLD_MARGIN
+
+        if ball_pos.y < -threshold_y:
             return True
         return False
 
@@ -535,8 +585,17 @@ class FieldObserver(Node):
     def get_ball_state(self):
         return self._ball_state
 
-    def ball_is_outside(self):
-        return self._ball_state == self.BALL_IS_OUTSIDE
+    def ball_is_outside_front_x(self):
+        return self._ball_state == self.BALL_IS_OUTSIDE_FRONT_X
+    
+    def ball_is_outside_back_x(self):
+        return self._ball_state == self.BALL_IS_OUTSIDE_BACK_X
+    
+    def ball_is_outside_right_y(self):
+        return self._ball_state == self.BALL_IS_OUTSIDE_RIGHT_Y
+
+    def ball_is_outside_left_y(self):
+        return self._ball_state == self.BALL_IS_OUTSIDE_LEFT_Y
 
     def ball_is_in_our_defense_area(self):
         return self._ball_state == self.BALL_IS_IN_OUR_DEFENSE_AREA

--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -52,8 +52,9 @@ def num_of_active_zone_roles(active_roles):
 
 def enable_update_attacker_by_ball_pos():
     # アタッカーの切り替わりを防ぐため、
-    # ボールが動いてたり、ディフェンスエリアにあるときは役割を更新しない
+    # ボールが動いてたり、ディフェンスエリアや自ゴール側場外にあるときは役割を更新しない
     return not observer.ball_is_in_our_defense_area() and \
+        not observer.ball_is_outside_back_x() and \
         not observer.ball_is_moving() and \
         not referee.our_ball_placement() and \
         not referee.our_pre_penalty() and \


### PR DESCRIPTION
# やったこと
- ボール場外判定を細分化（4パターン）
    - x方向に前後
    - y方向に左右
- アタッカーがボール追いかけない判定にボール場外フラグ追加（前後）
    - 相手のゴールの中や、ゴール裏にボールがあっても追いかけようとするためそれを防ぐ

# やってないこと
- 場外左右のときのアタッカーの動きは特に修正していません