### PR TITLE
ロボット座標系から見たロボット速度をrobot_local_velocitiesトピックとしてpublishする

### DIFF
--- a/consai_msgs/CMakeLists.txt
+++ b/consai_msgs/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(robocup_ssl_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 
 set(msg_files
@@ -29,6 +30,8 @@ set(msg_files
   "msg/GoalPose.msg"
   "msg/NamedTargets.msg"
   "msg/ParsedReferee.msg"
+  "msg/RobotLocalVelocities.msg"
+  "msg/RobotLocalVelocity.msg"
   "msg/State2D.msg"
 )
 
@@ -39,7 +42,7 @@ set(action_files
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${action_files}
-  DEPENDENCIES std_msgs
+  DEPENDENCIES std_msgs robocup_ssl_msgs
   ADD_LINTER_TESTS
 )
 

--- a/consai_msgs/msg/RobotLocalVelocities.msg
+++ b/consai_msgs/msg/RobotLocalVelocities.msg
@@ -1,0 +1,2 @@
+
+RobotLocalVelocity[] velocities

--- a/consai_msgs/msg/RobotLocalVelocity.msg
+++ b/consai_msgs/msg/RobotLocalVelocity.msg
@@ -1,0 +1,4 @@
+
+# ロボットから見たロボット速度を格納するメッセージ型
+robocup_ssl_msgs/RobotId robot_id
+State2D velocity

--- a/consai_msgs/package.xml
+++ b/consai_msgs/package.xml
@@ -12,6 +12,7 @@
 
   <depend>action_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>robocup_ssl_msgs</depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 

--- a/consai_vision_tracker/CMakeLists.txt
+++ b/consai_vision_tracker/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 
 # find dependencies
 find_package(ament_cmake REQUIRED)
+find_package(consai_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
 find_package(robocup_ssl_msgs REQUIRED)
@@ -36,6 +37,7 @@ add_library(tracker_component SHARED
 target_compile_definitions(tracker_component
   PRIVATE "CONSAI_VISION_TRACKER_BUILDING_DLL")
 ament_target_dependencies(tracker_component
+  consai_msgs
   rclcpp
   rclcpp_components
   robocup_ssl_msgs
@@ -48,6 +50,7 @@ rclcpp_components_register_nodes(tracker_component "consai_vision_tracker::Track
 # Exports
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
+ament_export_dependencies(consai_msgs)
 ament_export_dependencies(rclcpp)
 ament_export_dependencies(rclcpp_components)
 ament_export_dependencies(robocup_ssl_msgs)

--- a/consai_vision_tracker/include/consai_vision_tracker/robot_tracker.hpp
+++ b/consai_vision_tracker/include/consai_vision_tracker/robot_tracker.hpp
@@ -23,12 +23,14 @@
 #include <memory>
 #include <vector>
 
+#include "consai_msgs/msg/robot_local_velocity.hpp"
 #include "robocup_ssl_msgs/msg/detection_robot.hpp"
 #include "robocup_ssl_msgs/msg/tracked_robot.hpp"
 
 namespace consai_vision_tracker
 {
 
+using RobotLocalVelocity = consai_msgs::msg::RobotLocalVelocity;
 using DetectionRobot = robocup_ssl_msgs::msg::DetectionRobot;
 using TrackedRobot = robocup_ssl_msgs::msg::TrackedRobot;
 using ConditionalGaussian = BFL::LinearAnalyticConditionalGaussian;
@@ -44,6 +46,7 @@ public:
 
   void push_back_observation(const DetectionRobot & robot);
   TrackedRobot update();
+  RobotLocalVelocity calc_local_velocity();
 
 private:
   void reset_prior();

--- a/consai_vision_tracker/include/consai_vision_tracker/tracker_component.hpp
+++ b/consai_vision_tracker/include/consai_vision_tracker/tracker_component.hpp
@@ -18,6 +18,8 @@
 #include <memory>
 #include <vector>
 
+#include "consai_msgs/msg/robot_local_velocities.hpp"
+#include "consai_msgs/msg/robot_local_velocity.hpp"
 #include "consai_vision_tracker/visibility_control.h"
 #include "consai_vision_tracker/ball_tracker.hpp"
 #include "consai_vision_tracker/robot_tracker.hpp"
@@ -31,6 +33,8 @@
 namespace consai_vision_tracker
 {
 
+using RobotLocalVelocity = consai_msgs::msg::RobotLocalVelocity;
+using RobotLocalVelocities = consai_msgs::msg::RobotLocalVelocities;
 using DetectionBall = robocup_ssl_msgs::msg::DetectionBall;
 using DetectionFrame = robocup_ssl_msgs::msg::DetectionFrame;
 using DetectionRobot = robocup_ssl_msgs::msg::DetectionRobot;
@@ -54,6 +58,7 @@ private:
   rclcpp::TimerBase::SharedPtr timer_;
   rclcpp::Subscription<DetectionFrame>::SharedPtr sub_detection_;
   rclcpp::Publisher<TrackedFrame>::SharedPtr pub_tracked_;
+  rclcpp::Publisher<RobotLocalVelocities>::SharedPtr pub_robot_velocities_;
   std::shared_ptr<BallTracker> ball_tracker_;
   std::vector<std::shared_ptr<RobotTracker>> blue_robot_tracker_;
   std::vector<std::shared_ptr<RobotTracker>> yellow_robot_tracker_;

--- a/consai_vision_tracker/package.xml
+++ b/consai_vision_tracker/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>launch_ros</depend>
+  <depend>consai_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>robocup_ssl_msgs</depend>

--- a/consai_vision_tracker/src/robot_tracker.cpp
+++ b/consai_vision_tracker/src/robot_tracker.cpp
@@ -238,6 +238,27 @@ TrackedRobot RobotTracker::update()
   return prev_tracked_robot_;
 }
 
+RobotLocalVelocity RobotTracker::calc_local_velocity()
+{
+  // ロボット座標系でのロボット速度を計算する
+  auto local_velocity = RobotLocalVelocity();
+  local_velocity.robot_id = prev_tracked_robot_.robot_id;
+
+  if (prev_tracked_robot_.vel.size() > 0) {
+    auto theta = prev_tracked_robot_.orientation;
+    auto world_vel = prev_tracked_robot_.vel[0];
+    auto local_vel = world_vel;
+    local_vel.x = world_vel.x * std::cos(theta) + world_vel.y * std::sin(theta);
+    local_vel.y = -(world_vel.x * std::sin(theta) - world_vel.y * std::cos(theta));
+    local_velocity.velocity.x = local_vel.x;
+    local_velocity.velocity.y = local_vel.y;
+  }
+  if (prev_tracked_robot_.vel_angular.size() > 0) {
+    local_velocity.velocity.theta = prev_tracked_robot_.vel_angular[0];
+  }
+  return local_velocity;
+}
+
 void RobotTracker::reset_prior()
 {
   // 事前分布を初期化する


### PR DESCRIPTION
ロボット走行制御をデバッグするため、ロボット座標系からみたロボット速度を`robot_local_velocities`というトピックでpublishします。

デバッグ用のため、戦略や制御ではこのトピックを使用しません。

ロボットから見て、前後方向をX軸、左右方向をY軸として走行速度を変換してます。

start.launch.pyにて、`invert:=True`にしても問題なく速度を出力することを確認しています。