### PR TITLE
回避アルゴリズムの改善

### DIFF
--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -727,7 +727,7 @@ bool FieldInfoParser::avoid_obstacles(
   // 自身から直進方向に何m離れたロボットを障害物と判定するか
   const double OBSTACLE_DETECTION_X = 0.5;
   // 自身から直進方向に対して左右何m離れたロボットを障害物と判定するか
-  const double OBSTACLE_DETECTION_Y = 0.2;
+  const double OBSTACLE_DETECTION_Y = 0.5;
   // 相対的な回避位置
   const double AVOIDANCE_POS_X = 0.2;
   const double AVOIDANCE_POS_Y = 0.4;
@@ -740,18 +740,17 @@ bool FieldInfoParser::avoid_obstacles(
   tools::Trans trans_MtoG(my_robot_pose, tools::calc_angle(my_robot_pose, goal_pose));
   auto my_robot_pose_MtoG = std::make_shared<State>(trans_MtoG.transform(my_robot_pose));
   auto goal_pose_MtoG = trans_MtoG.transform(goal_pose);
+  // auto avoid_pose_MtoG = trans_MtoG.transform(goal_pose);
 
   double distance = 0.0; // 距離を格納する変数
   double distance_to_obstacle = 10000; // 適当な大きい数字を設定
   std::shared_ptr<State> obstacle_pose_MtoG;
 
   double distance_to_goal = std::hypot(goal_pose_MtoG.x, goal_pose_MtoG.y);
+  // double distance_to_avoid = std::hypot(avoid_pose_MtoG.x, avoid_pose_MtoG.y);
 
-
-  int count = 0;
   int i;
   for (i = 0; i < 6; i++) {
-    count ++;
 
     // ロボットに対して回避位置を生成
     for (const auto & robot : detection_tracked_->robots) {
@@ -774,17 +773,14 @@ bool FieldInfoParser::avoid_obstacles(
       auto robot_pose_MtoG = trans_MtoG.transform(robot_pose);
 
       distance = std::hypot(robot_pose_MtoG.x, robot_pose_MtoG.y);
-      if (OBSTACLE_DETECTION_X < robot_pose_MtoG.x &&
+      if (0.2 < robot_pose_MtoG.x &&
         robot_pose_MtoG.x < goal_pose_MtoG.x &&
         std::fabs(robot_pose_MtoG.y) < OBSTACLE_DETECTION_Y)
       {
-        // if ((robot_pose_MtoG.x < goal_pose_MtoG.x && count == 1) || 1 < count) {
-          // 最も自身に近いロボットを障害物とする
-          if (distance < distance_to_obstacle) {
-            obstacle_pose_MtoG = std::make_shared<State>(robot_pose_MtoG);
-            distance_to_obstacle = distance;
-            is_avoid_robot = true;  
-          // }
+        if (distance < distance_to_obstacle) {
+          obstacle_pose_MtoG = std::make_shared<State>(robot_pose_MtoG);
+          distance_to_obstacle = distance;
+          is_avoid_robot = true;  
         }
       }
     }
@@ -831,7 +827,7 @@ bool FieldInfoParser::avoid_obstacles(
       }
     }
     // 障害物と距離が近い場合
-    else if (obstacle_pose_MtoG->x < OBSTACLE_DETECTION_X) {
+    else if (is_avoid_robot && obstacle_pose_MtoG->x < OBSTACLE_DETECTION_X) {
       if (std::fabs(obstacle_pose_MtoG->y) < 0.3) {
         avoidance_pose = trans_MtoG.inverted_transform(
           obstacle_pose_MtoG->x,
@@ -859,111 +855,14 @@ bool FieldInfoParser::avoid_obstacles(
     is_avoid_robot = false;
     tools::Trans trans_MtoG(my_robot_pose, tools::calc_angle(my_robot_pose, avoidance_pose));
     my_robot_pose_MtoG = std::make_shared<State>(trans_MtoG.transform(my_robot_pose));
-    goal_pose_MtoG = trans_MtoG.transform(avoidance_pose);
+    // avoid_pose_MtoG = trans_MtoG.transform(avoidance_pose);
+    goal_pose_MtoG = trans_MtoG.transform(goal_pose);
 
     distance = 0.0;
     distance_to_obstacle = 10000;
     distance_to_goal = std::hypot(goal_pose_MtoG.x, goal_pose_MtoG.y);
+    // distance_to_avoid = std::hypot(avoid_pose_MtoG.x, avoid_pose_MtoG.y);
   }
-
-  // for (const auto & robot : detection_tracked_->robots) {
-  //   if (robot.visibility.size() == 0) {
-  //     continue;
-  //   }
-  //   if (robot.visibility[0] < VISIBILITY_THRESHOLD) {
-  //     continue;
-  //   }
-  // 
-  //   // 自身の情報は除外する
-  //   if (robot.robot_id.id == my_robot.robot_id.id &&
-  //     robot.robot_id.team_color == my_robot.robot_id.team_color)
-  //   {
-  //     continue;
-  //   }
-  // 
-  //   // ロボットの位置が自己位置と目標位置の間に存在するか判定
-  //   auto robot_pose = tools::pose_state(robot);
-  //   auto robot_pose_MtoG = trans_MtoG.transform(robot_pose);
-  // 
-  //   if (robot_pose_MtoG.x > OBSTACLE_DETECTION_X &&
-  //     robot_pose_MtoG.x < goal_pose_MtoG.x &&
-  //     std::fabs(robot_pose_MtoG.y) < OBSTACLE_DETECTION_Y)
-  //   {
-  //     // 最も自身に近いロボットを障害物とする
-  //     double distance = std::hypot(robot_pose_MtoG.x, robot_pose_MtoG.y);
-  //     if (distance < distance_to_obstacle) {
-  //       obstacle_pose_MtoG = std::make_shared<State>(robot_pose_MtoG);
-  //       distance_to_obstacle = distance;
-  //     }
-  //   }
-  // }
-  // 
-  // if (avoid_ball) {
-  //   auto ball_pose = tools::pose_state(ball);
-  //   auto ball_pose_MtoG = trans_MtoG.transform(ball_pose);
-  // 
-  //   double distance = std::hypot(ball_pose_MtoG.x, ball_pose_MtoG.y);
-  //   // 進路上にボールエリアがある場合
-  //   if (distance < 0.8 && std::fabs(ball_pose_MtoG.y) < 0.7)
-  //   {
-  //     if (distance < distance_to_obstacle) {
-  //       obstacle_pose_MtoG = std::make_shared<State>(ball_pose_MtoG);
-  //       distance_to_obstacle = distance;
-  //       is_avoid_ball = true;
-  //     }
-  //   }
-  // }
-  // 
-  // // 障害物が存在すれば、回避位置を生成する
-  // if (obstacle_pose_MtoG) {
-  //   // STOPゲーム中でボールが進路上にある場合
-  //   if (is_avoid_ball) {
-  //     if (distance_to_obstacle < 0.7) {
-  //       if (distance_to_obstacle < distance_to_goal) {
-  //         avoidance_pose = trans_MtoG.inverted_transform(
-  //           obstacle_pose_MtoG->x,
-  //           obstacle_pose_MtoG->y - std::copysign(0.7, obstacle_pose_MtoG->y),
-  //           goal_pose_MtoG.theta
-  //         );
-  //       }
-  //     }
-  //     else {
-  //       avoidance_pose = trans_MtoG.inverted_transform(
-  //         obstacle_pose_MtoG->x + 0.2,
-  //         obstacle_pose_MtoG->y + std::copysign(0.2, obstacle_pose_MtoG->y),
-  //         goal_pose_MtoG.theta
-  //       );
-  //     }
-  // 
-  //   }
-  //   // 障害物と距離が近い場合
-  //   else if (obstacle_pose_MtoG->x < OBSTACLE_DETECTION_X) {
-  //     if (std::fabs(obstacle_pose_MtoG->y) < 0.2) {
-  //       avoidance_pose = trans_MtoG.inverted_transform(
-  //         obstacle_pose_MtoG->x,
-  //         obstacle_pose_MtoG->y - std::copysign(AVOIDANCE_POS_Y, obstacle_pose_MtoG->y),
-  //         goal_pose_MtoG.theta
-  //       );
-  //     }
-  //     else {
-  //       avoidance_pose = trans_MtoG.inverted_transform(
-  //         obstacle_pose_MtoG->x + AVOIDANCE_POS_X / 2,
-  //         obstacle_pose_MtoG->y - std::copysign(AVOIDANCE_POS_Y, obstacle_pose_MtoG->y),
-  //         goal_pose_MtoG.theta
-  //       );
-  //     }
-  //   }
-  //   // 障害物と距離が近い場合
-  //   else{
-  //     avoidance_pose = trans_MtoG.inverted_transform(
-  //       obstacle_pose_MtoG->x + AVOIDANCE_POS_X,
-  //       obstacle_pose_MtoG->y - std::copysign(AVOIDANCE_POS_Y, obstacle_pose_MtoG->y),
-  //       goal_pose_MtoG.theta
-  //     );
-  //   }
-  // }
-
-
   return true;
 }
 

--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -732,6 +732,8 @@ bool FieldInfoParser::avoid_obstacles(
   const double AVOIDANCE_POS_X = 0.2;
   const double AVOIDANCE_POS_Y = 0.4;
 
+  double avoidance_pos_x = 0.0;
+
   // ボール回避判定フラグ
   bool is_avoid_ball = false;
   bool is_avoid_robot = false;
@@ -827,27 +829,22 @@ bool FieldInfoParser::avoid_obstacles(
       }
     }
     // 障害物と距離が近い場合
-    else if (is_avoid_robot && obstacle_pose_MtoG->x < OBSTACLE_DETECTION_X) {
-      if (std::fabs(obstacle_pose_MtoG->y) < 0.3) {
-        avoidance_pose = trans_MtoG.inverted_transform(
-          obstacle_pose_MtoG->x,
-          obstacle_pose_MtoG->y - std::copysign(AVOIDANCE_POS_Y, obstacle_pose_MtoG->y),
-          goal_pose_MtoG.theta
-        );
+    else if (is_avoid_robot) {
+      if (obstacle_pose_MtoG->x < OBSTACLE_DETECTION_X) {
+        if (std::fabs(obstacle_pose_MtoG->y) < 0.3) {
+          avoidance_pos_x = 0.05;
+        }
+        else {
+          avoidance_pos_x = 0.1;
+        }
       }
       else {
-        avoidance_pose = trans_MtoG.inverted_transform(
-          obstacle_pose_MtoG->x + AVOIDANCE_POS_X / 2,
-          obstacle_pose_MtoG->y - std::copysign(AVOIDANCE_POS_Y, obstacle_pose_MtoG->y),
-          goal_pose_MtoG.theta
-        );
+        avoidance_pos_x = 0.2;
       }
-    }
-    else {
       avoidance_pose = trans_MtoG.inverted_transform(
-        obstacle_pose_MtoG->x + AVOIDANCE_POS_X,
+        obstacle_pose_MtoG->x + avoidance_pos_x,
         obstacle_pose_MtoG->y - std::copysign(AVOIDANCE_POS_Y, obstacle_pose_MtoG->y),
-        goal_pose_MtoG.theta
+          goal_pose_MtoG.theta
       );
     }
 

--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -726,10 +726,8 @@ bool FieldInfoParser::avoid_obstacles(
   const double VISIBILITY_THRESHOLD = 0.01;  // 0.0 ~ 1.0
   // 自身から直進方向に何m離れたロボットを障害物と判定するか
   const double OBSTACLE_DETECTION_X = 0.5;
-  const double OBSTACLE_DETECTION_X_LONG = 1.0;
   // 自身から直進方向に対して左右何m離れたロボットを障害物と判定するか
-  const double OBSTACLE_DETECTION_Y = 0.3;
-  const double OBSTACLE_DETECTION_Y_SHORT = 0.3;
+  const double OBSTACLE_DETECTION_Y_ROBOT = 0.3;
   const double OBSTACLE_DETECTION_Y_BALL = 0.2;
   // 回避の相対位置
   const double AVOIDANCE_POS_X_SHORT = 0.1;
@@ -748,8 +746,6 @@ bool FieldInfoParser::avoid_obstacles(
   // 回避位置の初期値を目標位置にする
   avoidance_pose = goal_pose;
 
-  tools::Trans trans_MtoG(my_robot_pose, tools::calc_angle(my_robot_pose, goal_pose));
-  auto goal_pose_MtoG = trans_MtoG.transform(goal_pose);
   std::shared_ptr<State> obstacle_pose_MtoA;
 
   // 回避位置生成と回避位置-自己位置間の障害物を検索するためのループ
@@ -786,8 +782,8 @@ bool FieldInfoParser::avoid_obstacles(
 
       distance = std::hypot(robot_pose_MtoA.x, robot_pose_MtoA.y);
       if (0 < robot_pose_MtoA.x &&
-        robot_pose_MtoA.x < goal_pose_MtoG.x &&
-        std::fabs(robot_pose_MtoA.y) < OBSTACLE_DETECTION_Y)
+        robot_pose_MtoA.x < avoidance_pose_MtoA.x &&
+        std::fabs(robot_pose_MtoA.y) < OBSTACLE_DETECTION_Y_ROBOT)
       {
         if (distance < distance_to_obstacle) {
           obstacle_pose_MtoA = std::make_shared<State>(robot_pose_MtoA);
@@ -805,7 +801,7 @@ bool FieldInfoParser::avoid_obstacles(
       distance = std::hypot(ball_pose_MtoA.x, ball_pose_MtoA.y);
       // 進路上にボールエリアがある場合
       if (0 < ball_pose_MtoA.x &&
-        ball_pose_MtoA.x < goal_pose_MtoG.x &&
+        ball_pose_MtoA.x < avoidance_pose_MtoA.x &&
         std::fabs(ball_pose_MtoA.y) < OBSTACLE_DETECTION_Y_BALL)
       {
         if (distance < distance_to_obstacle) {

--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -728,14 +728,13 @@ bool FieldInfoParser::avoid_obstacles(
   const double OBSTACLE_DETECTION_X = 0.5;
   const double OBSTACLE_DETECTION_X_LONG = 1.0;
   // 自身から直進方向に対して左右何m離れたロボットを障害物と判定するか
-  const double OBSTACLE_DETECTION_Y = 0.5;
+  const double OBSTACLE_DETECTION_Y = 0.3;
   const double OBSTACLE_DETECTION_Y_SHORT = 0.3;
   const double OBSTACLE_DETECTION_Y_BALL = 0.2;
   // 回避の相対位置
-  const double AVOIDANCE_POS_X_SHORT = 0.05;
-  const double AVOIDANCE_POS_X_MIDDLE = 0.1;
+  const double AVOIDANCE_POS_X_SHORT = 0.1;
   const double AVOIDANCE_POS_X_LONG = 0.2;
-  const double AVOIDANCE_POS_Y = 0.5;
+  const double AVOIDANCE_POS_Y = 0.4;
 
   // 相対的な回避位置
   double avoidance_pos_x = 0.0;
@@ -828,12 +827,7 @@ bool FieldInfoParser::avoid_obstacles(
       avoidance_pos_y = - std::copysign(AVOIDANCE_POS_Y, obstacle_pose_MtoA->y);
       // 障害物と距離が近い場合
       if (obstacle_pose_MtoA->x < OBSTACLE_DETECTION_X) {
-        if (std::fabs(obstacle_pose_MtoA->y) < OBSTACLE_DETECTION_Y_SHORT) {
-          avoidance_pos_x = AVOIDANCE_POS_X_SHORT;
-        }
-        else {
-          avoidance_pos_x = AVOIDANCE_POS_X_MIDDLE;
-        }
+        avoidance_pos_x = AVOIDANCE_POS_X_SHORT;
       }
       else {
         avoidance_pos_x = AVOIDANCE_POS_X_LONG;


### PR DESCRIPTION
> #66 の改善
> 
> - ボールが進路上にあるか判定
>   - Trans後のy座標で判定
> - 進路上にあれば回避
>   - まだ少し不安定さはあるがかなり改善された

元々上記のような対応だったが，通常の回避行動を改善にした

STOP中のボール回避はavoid_ball_500mm()で生成することにした