### PR TITLE
ペナルティ後に相手ディフェンスエリアに侵入しないように、待機位置を変更した

### DIFF
--- a/consai_examples/consai_examples/decisions/attacker.py
+++ b/consai_examples/consai_examples/decisions/attacker.py
@@ -23,6 +23,8 @@ class AttackerDecision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
+        self._PENALTY_WAIT_X = 4.5  # ペナルティキック待機位置のX座標
+
     def stop(self, robot_id):
         ID_CHASE = self.ACT_ID_STOP + 0
         ID_IN_OUR_DEFENSE = self.ACT_ID_STOP + 1
@@ -103,17 +105,17 @@ class AttackerDecision(DecisionBase):
 
     def their_pre_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PRE_PENALTY:
-            self._operator.move_to_look_ball(robot_id, 6.0 - 0.5, 4.5 - 0.3 * 0.0)
+            self._operator.move_to_look_ball(robot_id, self._PENALTY_WAIT_X, 4.5 - 0.3 * 0.0)
             self._act_id = self.ACT_ID_PRE_PENALTY
 
     def their_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PENALTY:
-            self._operator.move_to_look_ball(robot_id, 6.0 - 0.5, 4.5 - 0.3 * 0.0)
+            self._operator.move_to_look_ball(robot_id, self._PENALTY_WAIT_X, 4.5 - 0.3 * 0.0)
             self._act_id = self.ACT_ID_PENALTY
 
     def their_penalty_inplay(self, robot_id):
         if self._act_id != self.ACT_ID_INPLAY:
-            self._operator.move_to_look_ball(robot_id, 6.0 - 0.5, 4.5 - 0.3 * 0.0)
+            self._operator.move_to_look_ball(robot_id, self._PENALTY_WAIT_X, 4.5 - 0.3 * 0.0)
             self._act_id = self.ACT_ID_INPLAY
 
     def our_penalty_inplay(self, robot_id):

--- a/consai_examples/consai_examples/decisions/attacker.py
+++ b/consai_examples/consai_examples/decisions/attacker.py
@@ -23,7 +23,7 @@ class AttackerDecision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
-        self._PENALTY_WAIT_X = 4.5  # ペナルティキック待機位置のX座標
+        self._PENALTY_WAIT_X = 4.1  # ペナルティキック待機位置のX座標
 
     def stop(self, robot_id):
         ID_CHASE = self.ACT_ID_STOP + 0

--- a/consai_examples/consai_examples/decisions/attacker.py
+++ b/consai_examples/consai_examples/decisions/attacker.py
@@ -23,8 +23,6 @@ class AttackerDecision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
-        self._PENALTY_WAIT_X = 4.1  # ペナルティキック待機位置のX座標
-
     def stop(self, robot_id):
         ID_CHASE = self.ACT_ID_STOP + 0
         ID_IN_OUR_DEFENSE = self.ACT_ID_STOP + 1

--- a/consai_examples/consai_examples/decisions/center_back1.py
+++ b/consai_examples/consai_examples/decisions/center_back1.py
@@ -23,7 +23,7 @@ class CenterBack1Decision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
-        self._PENALTY_WAIT_X = 4.5  # ペナルティキック待機位置のX座標
+        self._PENALTY_WAIT_X = 4.1  # ペナルティキック待機位置のX座標
 
     def _defend_upper_defense_area(self, robot_id, base_id):
         # ディフェンスエリアの上半分を守る

--- a/consai_examples/consai_examples/decisions/center_back1.py
+++ b/consai_examples/consai_examples/decisions/center_back1.py
@@ -23,6 +23,8 @@ class CenterBack1Decision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
+        self._PENALTY_WAIT_X = 4.5  # ペナルティキック待機位置のX座標
+
     def _defend_upper_defense_area(self, robot_id, base_id):
         # ディフェンスエリアの上半分を守る
         ID_UPPER = base_id + 100
@@ -94,22 +96,22 @@ class CenterBack1Decision(DecisionBase):
 
     def our_pre_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PRE_PENALTY:
-            self._operator.move_to_look_ball(robot_id, -6.0 + 0.5, 4.5 - 0.3 * 1.0)
+            self._operator.move_to_look_ball(robot_id, -self._PENALTY_WAIT_X, 4.5 - 0.3 * 1.0)
             self._act_id = self.ACT_ID_PRE_PENALTY
 
     def our_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PENALTY:
-            self._operator.move_to_look_ball(robot_id, -6.0 + 0.5, 4.5 - 0.3 * 1.0)
+            self._operator.move_to_look_ball(robot_id, -self._PENALTY_WAIT_X, 4.5 - 0.3 * 1.0)
             self._act_id = self.ACT_ID_PENALTY
 
     def their_pre_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PRE_PENALTY:
-            self._operator.move_to_look_ball(robot_id, 6.0 - 0.5, 4.5 - 0.3 * 1.0)
+            self._operator.move_to_look_ball(robot_id, self._PENALTY_WAIT_X, 4.5 - 0.3 * 1.0)
             self._act_id = self.ACT_ID_PRE_PENALTY
 
     def their_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PENALTY:
-            self._operator.move_to_look_ball(robot_id, 6.0 - 0.5, 4.5 - 0.3 * 1.0)
+            self._operator.move_to_look_ball(robot_id, self._PENALTY_WAIT_X, 4.5 - 0.3 * 1.0)
             self._act_id = self.ACT_ID_PENALTY
 
     def our_penalty_inplay(self, robot_id):

--- a/consai_examples/consai_examples/decisions/center_back1.py
+++ b/consai_examples/consai_examples/decisions/center_back1.py
@@ -23,8 +23,6 @@ class CenterBack1Decision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
-        self._PENALTY_WAIT_X = 4.1  # ペナルティキック待機位置のX座標
-
     def _defend_upper_defense_area(self, robot_id, base_id):
         # ディフェンスエリアの上半分を守る
         ID_UPPER = base_id + 100

--- a/consai_examples/consai_examples/decisions/center_back2.py
+++ b/consai_examples/consai_examples/decisions/center_back2.py
@@ -23,6 +23,8 @@ class CenterBack2Decision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
+        self._PENALTY_WAIT_X = 4.5  # ペナルティキック待機位置のX座標
+
     def _defend_lower_defense_area(self, robot_id, base_id):
         # ディフェンスエリアの下半分を守る
         ID_LOWER = base_id + 100
@@ -92,22 +94,22 @@ class CenterBack2Decision(DecisionBase):
 
     def our_pre_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PRE_PENALTY:
-            self._operator.move_to_look_ball(robot_id, -6.0 + 0.5, 4.5 - 0.3 * 2.0)
+            self._operator.move_to_look_ball(robot_id, -self._PENALTY_WAIT_X, 4.5 - 0.3 * 2.0)
             self._act_id = self.ACT_ID_PRE_PENALTY
 
     def our_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PENALTY:
-            self._operator.move_to_look_ball(robot_id, -6.0 + 0.5, 4.5 - 0.3 * 2.0)
+            self._operator.move_to_look_ball(robot_id, -self._PENALTY_WAIT_X, 4.5 - 0.3 * 2.0)
             self._act_id = self.ACT_ID_PENALTY
 
     def their_pre_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PRE_PENALTY:
-            self._operator.move_to_look_ball(robot_id, 6.0 - 0.5, 4.5 - 0.3 * 2.0)
+            self._operator.move_to_look_ball(robot_id, self._PENALTY_WAIT_X, 4.5 - 0.3 * 2.0)
             self._act_id = self.ACT_ID_PRE_PENALTY
 
     def their_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PENALTY:
-            self._operator.move_to_look_ball(robot_id, 6.0 - 0.5, 4.5 - 0.3 * 2.0)
+            self._operator.move_to_look_ball(robot_id, self._PENALTY_WAIT_X, 4.5 - 0.3 * 2.0)
             self._act_id = self.ACT_ID_PENALTY
 
     def our_penalty_inplay(self, robot_id):

--- a/consai_examples/consai_examples/decisions/center_back2.py
+++ b/consai_examples/consai_examples/decisions/center_back2.py
@@ -23,7 +23,7 @@ class CenterBack2Decision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
-        self._PENALTY_WAIT_X = 4.5  # ペナルティキック待機位置のX座標
+        self._PENALTY_WAIT_X = 4.1  # ペナルティキック待機位置のX座標
 
     def _defend_lower_defense_area(self, robot_id, base_id):
         # ディフェンスエリアの下半分を守る

--- a/consai_examples/consai_examples/decisions/center_back2.py
+++ b/consai_examples/consai_examples/decisions/center_back2.py
@@ -23,8 +23,6 @@ class CenterBack2Decision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
-        self._PENALTY_WAIT_X = 4.1  # ペナルティキック待機位置のX座標
-
     def _defend_lower_defense_area(self, robot_id, base_id):
         # ディフェンスエリアの下半分を守る
         ID_LOWER = base_id + 100

--- a/consai_examples/consai_examples/decisions/decision_base.py
+++ b/consai_examples/consai_examples/decisions/decision_base.py
@@ -42,6 +42,7 @@ class DecisionBase(object):
         self._num_of_zone_roles = 0
         self._zone_targets = {0: None, 1: None, 2: None, 3: None}
         self._act_id = self.ACT_ID_INIT
+        self._PENALTY_WAIT_X = 4.1  # ペナルティキック待機位置のX座標
 
     def enable_stop_game_velocity(self, robot_id):
         self._operator.enable_stop_game_velocity(robot_id)

--- a/consai_examples/consai_examples/decisions/side_back1.py
+++ b/consai_examples/consai_examples/decisions/side_back1.py
@@ -23,8 +23,6 @@ class SideBack1Decision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
-        self._PENALTY_WAIT_X = 4.1  # ペナルティキック待機位置のX座標
-
     def _defend_upper_defense_area(self, robot_id):
         # ディフェンスエリアの上側を守る
         p1_x = -6.0 + 0.3

--- a/consai_examples/consai_examples/decisions/side_back1.py
+++ b/consai_examples/consai_examples/decisions/side_back1.py
@@ -23,7 +23,7 @@ class SideBack1Decision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
-        self._PENALTY_WAIT_X = 4.5  # ペナルティキック待機位置のX座標
+        self._PENALTY_WAIT_X = 4.1  # ペナルティキック待機位置のX座標
 
     def _defend_upper_defense_area(self, robot_id):
         # ディフェンスエリアの上側を守る

--- a/consai_examples/consai_examples/decisions/side_back1.py
+++ b/consai_examples/consai_examples/decisions/side_back1.py
@@ -23,6 +23,8 @@ class SideBack1Decision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
+        self._PENALTY_WAIT_X = 4.5  # ペナルティキック待機位置のX座標
+
     def _defend_upper_defense_area(self, robot_id):
         # ディフェンスエリアの上側を守る
         p1_x = -6.0 + 0.3
@@ -72,22 +74,22 @@ class SideBack1Decision(DecisionBase):
 
     def our_pre_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PRE_PENALTY:
-            self._operator.move_to_look_ball(robot_id, -6.0 + 0.5, 4.5 - 0.3 * 3.0)
+            self._operator.move_to_look_ball(robot_id, -self._PENALTY_WAIT_X, 4.5 - 0.3 * 3.0)
             self._act_id = self.ACT_ID_PRE_PENALTY
 
     def our_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PENALTY:
-            self._operator.move_to_look_ball(robot_id, -6.0 + 0.5, 4.5 - 0.3 * 3.0)
+            self._operator.move_to_look_ball(robot_id, -self._PENALTY_WAIT_X, 4.5 - 0.3 * 3.0)
             self._act_id = self.ACT_ID_PENALTY
 
     def their_pre_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PRE_PENALTY:
-            self._operator.move_to_look_ball(robot_id, 6.0 - 0.5, 4.5 - 0.3 * 3.0)
+            self._operator.move_to_look_ball(robot_id, self._PENALTY_WAIT_X, 4.5 - 0.3 * 3.0)
             self._act_id = self.ACT_ID_PRE_PENALTY
 
     def their_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PENALTY:
-            self._operator.move_to_look_ball(robot_id, 6.0 - 0.5, 4.5 - 0.3 * 3.0)
+            self._operator.move_to_look_ball(robot_id, self._PENALTY_WAIT_X, 4.5 - 0.3 * 3.0)
             self._act_id = self.ACT_ID_PENALTY
 
     def our_penalty_inplay(self, robot_id):

--- a/consai_examples/consai_examples/decisions/side_back2.py
+++ b/consai_examples/consai_examples/decisions/side_back2.py
@@ -23,7 +23,7 @@ class SideBack2Decision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
-        self._PENALTY_WAIT_X = 4.5  # ペナルティキック待機位置のX座標
+        self._PENALTY_WAIT_X = 4.1  # ペナルティキック待機位置のX座標
 
     def _defend_lower_defense_area(self, robot_id):
         # ディフェンスエリアの下側を守る

--- a/consai_examples/consai_examples/decisions/side_back2.py
+++ b/consai_examples/consai_examples/decisions/side_back2.py
@@ -23,6 +23,8 @@ class SideBack2Decision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
+        self._PENALTY_WAIT_X = 4.5  # ペナルティキック待機位置のX座標
+
     def _defend_lower_defense_area(self, robot_id):
         # ディフェンスエリアの下側を守る
         p1_x = -6.0 + 0.3
@@ -72,22 +74,22 @@ class SideBack2Decision(DecisionBase):
 
     def our_pre_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PRE_PENALTY:
-            self._operator.move_to_look_ball(robot_id, -6.0 + 0.5, 4.5 - 0.3 * 4.0)
+            self._operator.move_to_look_ball(robot_id, -self._PENALTY_WAIT_X, 4.5 - 0.3 * 4.0)
             self._act_id = self.ACT_ID_PRE_PENALTY
 
     def our_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PENALTY:
-            self._operator.move_to_look_ball(robot_id, -6.0 + 0.5, 4.5 - 0.3 * 4.0)
+            self._operator.move_to_look_ball(robot_id, -self._PENALTY_WAIT_X, 4.5 - 0.3 * 4.0)
             self._act_id = self.ACT_ID_PENALTY
 
     def their_pre_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PRE_PENALTY:
-            self._operator.move_to_look_ball(robot_id, 6.0 - 0.5, 4.5 - 0.3 * 4.0)
+            self._operator.move_to_look_ball(robot_id, self._PENALTY_WAIT_X, 4.5 - 0.3 * 4.0)
             self._act_id = self.ACT_ID_PRE_PENALTY
 
     def their_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PENALTY:
-            self._operator.move_to_look_ball(robot_id, 6.0 - 0.5, 4.5 - 0.3 * 4.0)
+            self._operator.move_to_look_ball(robot_id, self._PENALTY_WAIT_X, 4.5 - 0.3 * 4.0)
             self._act_id = self.ACT_ID_PENALTY
 
     def our_penalty_inplay(self, robot_id):

--- a/consai_examples/consai_examples/decisions/side_back2.py
+++ b/consai_examples/consai_examples/decisions/side_back2.py
@@ -23,8 +23,6 @@ class SideBack2Decision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
-        self._PENALTY_WAIT_X = 4.1  # ペナルティキック待機位置のX座標
-
     def _defend_lower_defense_area(self, robot_id):
         # ディフェンスエリアの下側を守る
         p1_x = -6.0 + 0.3

--- a/consai_examples/consai_examples/decisions/sub_attacker.py
+++ b/consai_examples/consai_examples/decisions/sub_attacker.py
@@ -23,8 +23,6 @@ class SubAttackerDecision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
-        self._PENALTY_WAIT_X = 4.1  # ペナルティキック待機位置のX座標
-
         self._ZONE_TOPS = [FieldObserver.BALL_ZONE_LEFT_TOP, FieldObserver.BALL_ZONE_RIGHT_TOP,
                            FieldObserver.BALL_ZONE_LEFT_MID_TOP, FieldObserver.BALL_ZONE_RIGHT_MID_TOP]
 

--- a/consai_examples/consai_examples/decisions/sub_attacker.py
+++ b/consai_examples/consai_examples/decisions/sub_attacker.py
@@ -23,6 +23,8 @@ class SubAttackerDecision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
+        self._PENALTY_WAIT_X = 4.5  # ペナルティキック待機位置のX座標
+
         self._ZONE_TOPS = [FieldObserver.BALL_ZONE_LEFT_TOP, FieldObserver.BALL_ZONE_RIGHT_TOP,
                            FieldObserver.BALL_ZONE_LEFT_MID_TOP, FieldObserver.BALL_ZONE_RIGHT_MID_TOP]
 
@@ -94,22 +96,22 @@ class SubAttackerDecision(DecisionBase):
 
     def our_pre_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PRE_PENALTY:
-            self._operator.move_to_look_ball(robot_id, -6.0 + 0.5, 4.5 - 0.3 * 5.0)
+            self._operator.move_to_look_ball(robot_id, -self._PENALTY_WAIT_X, 4.5 - 0.3 * 5.0)
             self._act_id = self.ACT_ID_PRE_PENALTY
 
     def our_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PRE_PENALTY:
-            self._operator.move_to_look_ball(robot_id, -6.0 + 0.5, 4.5 - 0.3 * 5.0)
+            self._operator.move_to_look_ball(robot_id, -self._PENALTY_WAIT_X, 4.5 - 0.3 * 5.0)
             self._act_id = self.ACT_ID_PRE_PENALTY
 
     def their_pre_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PRE_PENALTY:
-            self._operator.move_to_look_ball(robot_id, 6.0 - 0.5, 4.5 - 0.3 * 5.0)
+            self._operator.move_to_look_ball(robot_id, self._PENALTY_WAIT_X, 4.5 - 0.3 * 5.0)
             self._act_id = self.ACT_ID_PRE_PENALTY
 
     def their_penalty(self, robot_id):
         if self._act_id != self.ACT_ID_PRE_PENALTY:
-            self._operator.move_to_look_ball(robot_id, 6.0 - 0.5, 4.5 - 0.3 * 5.0)
+            self._operator.move_to_look_ball(robot_id, self._PENALTY_WAIT_X, 4.5 - 0.3 * 5.0)
             self._act_id = self.ACT_ID_PRE_PENALTY
 
     def our_penalty_inplay(self, robot_id):

--- a/consai_examples/consai_examples/decisions/sub_attacker.py
+++ b/consai_examples/consai_examples/decisions/sub_attacker.py
@@ -23,7 +23,7 @@ class SubAttackerDecision(DecisionBase):
     def __init__(self, robot_operator, field_observer):
         super().__init__(robot_operator, field_observer)
 
-        self._PENALTY_WAIT_X = 4.5  # ペナルティキック待機位置のX座標
+        self._PENALTY_WAIT_X = 4.1  # ペナルティキック待機位置のX座標
 
         self._ZONE_TOPS = [FieldObserver.BALL_ZONE_LEFT_TOP, FieldObserver.BALL_ZONE_RIGHT_TOP,
                            FieldObserver.BALL_ZONE_LEFT_MID_TOP, FieldObserver.BALL_ZONE_RIGHT_MID_TOP]

--- a/consai_examples/consai_examples/decisions/zone_defense.py
+++ b/consai_examples/consai_examples/decisions/zone_defense.py
@@ -35,9 +35,9 @@ class ZoneDefenseDecision(DecisionBase):
     def __init__(self, robot_operator, field_observer, zone_id: ZoneDefenseID):
         super().__init__(robot_operator, field_observer)
         self._zone_id = zone_id
-        self._our_penalty_pos_x = -6.0 + 0.5
+        self._our_penalty_pos_x = -4.5
         self._our_penalty_pos_y = 4.5 - 0.3 * (6.0 + self._zone_id.value)
-        self._their_penalty_pos_x = 6.0 - 0.5
+        self._their_penalty_pos_x = 4.5
         self._their_penalty_pos_y = 4.5 - 0.3 * (6.0 + self._zone_id.value)
         self._ball_placement_pos_x = -6.0 + 2.0
         self._ball_placement_pos_y = 1.8 - 0.3 * (4.0 + self._zone_id.value)

--- a/consai_examples/consai_examples/decisions/zone_defense.py
+++ b/consai_examples/consai_examples/decisions/zone_defense.py
@@ -35,9 +35,9 @@ class ZoneDefenseDecision(DecisionBase):
     def __init__(self, robot_operator, field_observer, zone_id: ZoneDefenseID):
         super().__init__(robot_operator, field_observer)
         self._zone_id = zone_id
-        self._our_penalty_pos_x = -4.5
+        self._our_penalty_pos_x = -4.1
         self._our_penalty_pos_y = 4.5 - 0.3 * (6.0 + self._zone_id.value)
-        self._their_penalty_pos_x = 4.5
+        self._their_penalty_pos_x = 4.1
         self._their_penalty_pos_y = 4.5 - 0.3 * (6.0 + self._zone_id.value)
         self._ball_placement_pos_x = -6.0 + 2.0
         self._ball_placement_pos_y = 1.8 - 0.3 * (4.0 + self._zone_id.value)

--- a/consai_examples/consai_examples/decisions/zone_defense.py
+++ b/consai_examples/consai_examples/decisions/zone_defense.py
@@ -35,9 +35,9 @@ class ZoneDefenseDecision(DecisionBase):
     def __init__(self, robot_operator, field_observer, zone_id: ZoneDefenseID):
         super().__init__(robot_operator, field_observer)
         self._zone_id = zone_id
-        self._our_penalty_pos_x = -4.1
+        self._our_penalty_pos_x = -self._PENALTY_WAIT_X
         self._our_penalty_pos_y = 4.5 - 0.3 * (6.0 + self._zone_id.value)
-        self._their_penalty_pos_x = 4.1
+        self._their_penalty_pos_x = self._PENALTY_WAIT_X
         self._their_penalty_pos_y = 4.5 - 0.3 * (6.0 + self._zone_id.value)
         self._ball_placement_pos_x = -6.0 + 2.0
         self._ball_placement_pos_y = 1.8 - 0.3 * (4.0 + self._zone_id.value)


### PR DESCRIPTION
ペナルティキック終了後、各ロボットが持ち場に戻るとき、ディフェンスエリアに侵入することがありました。

ペナルティキックでの待機位置を変更して、侵入を防ぎます。

![image](https://user-images.githubusercontent.com/18494952/235876526-8dead847-e74c-4662-9aaf-07202fcaa053.png)


## ルール

- 試合を再開する前の、停止、フリーキックの間、すべてのロボットは相手のディフェンスエリアから少なくとも0.2m以上離れていなければならない。
- ロボットが相手ディフェンスエリアから離れるため、2秒間の猶予が設けられる。
