### PR TITLE
速度参照タイミングの違いでNoneにならないようにdeepcopy()で値を取得

### DIFF
--- a/consai_examples/consai_examples/field_observer.py
+++ b/consai_examples/consai_examples/field_observer.py
@@ -132,9 +132,6 @@ class FieldObserver(Node):
             eval(object_str + "angle")[robot_id] = robot.orientation
             if robot.vel:
                 eval(object_str + "vel")[robot_id] = [robot.vel[0].x, robot.vel[0].y]
-            else:
-                # TODO: 速度がNoneになる場合があるため，エラー処理のため(0.0, 0.0)を代入
-                eval(object_str + "vel")[robot_id] = [0.0, 0.0]
             if robot.vel_angular:
                 eval(object_str + "vel_angle")[robot_id] = robot.vel_angular
 
@@ -736,11 +733,15 @@ class FieldObserver(Node):
 
     def _forward_robots_id(self, my_robot_id, my_robot_pos, robots_pos, robots_vel, robot_r, dt, is_delete_my_id=False):
         # フィールド上にいる味方ロボットのIDのみリスト化
-        robots_id = self.get_robots_id(robots_pos)
+        robots_id = []
+        for robot_id, robot_pos in enumerate(robots_pos):
+            if robot_pos is not None:
+                robots_id.append(robot_id)
         
         if is_delete_my_id:
-            # 自身のIDを削除
-            robots_id.remove(my_robot_id)
+            if is_delete_my_id in robots_id:
+                # 自身のIDを削除
+                robots_id.remove(my_robot_id)
 
         # パサーより前に存在するロボットIDをリスト化
         # TODO: ここ、geometry_toolsのTrans使えばきれいに書けそう

--- a/consai_examples/consai_examples/field_observer.py
+++ b/consai_examples/consai_examples/field_observer.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 import math
+import copy
 
 from rclpy.node import Node
 from robocup_ssl_msgs.msg import TrackedBall
@@ -640,10 +641,10 @@ class FieldObserver(Node):
         dt = 0.5
 
         # 各ロボットの位置と速度を取得
-        our_robots_pos = self.our_robots_pos
-        their_robots_pos = self.their_robots_pos
-        our_robots_vel = self.our_robots_vel
-        their_robots_vel = self.their_robots_vel
+        our_robots_pos = copy.deepcopy(self.our_robots_pos)
+        their_robots_pos = copy.deepcopy(self.their_robots_pos)
+        our_robots_vel = copy.deepcopy(self.our_robots_vel)
+        their_robots_vel = copy.deepcopy(self.their_robots_vel)
 
         # パサーの位置
         if my_robot_id >= len(our_robots_pos):

--- a/consai_examples/consai_examples/field_observer.py
+++ b/consai_examples/consai_examples/field_observer.py
@@ -130,14 +130,16 @@ class FieldObserver(Node):
             object_str = "self." + team_str + "_robots_"
             eval(object_str + "pos")[robot_id] = [robot.pos.x, robot.pos.y]
             eval(object_str + "angle")[robot_id] = robot.orientation
+
             if robot.vel:
                 eval(object_str + "vel")[robot_id] = [robot.vel[0].x, robot.vel[0].y]
             if robot.vel_angular:
                 eval(object_str + "vel_angle")[robot_id] = robot.vel_angular
 
-    def get_robots_id(self, robots_pos):
+    def get_robots_id(self, robots_info):
         # フィールド上にいるロボットのIDをリスト化
-        robots_id = [robot_id for robot_id in range(len(robots_pos)) if robots_pos[robot_id] != None]
+        # robots_infoはロボットの位置か速度を渡す
+        robots_id = [robot_id for robot_id in range(len(robots_info)) if robots_info[robot_id] != None]
         return robots_id
 
     def _update_ball_state(self, ball):
@@ -733,14 +735,11 @@ class FieldObserver(Node):
 
     def _forward_robots_id(self, my_robot_id, my_robot_pos, robots_pos, robots_vel, robot_r, dt, is_delete_my_id=False):
         # フィールド上にいる味方ロボットのIDのみリスト化
-        robots_id = []
-        for robot_id, robot_pos in enumerate(robots_pos):
-            if robot_pos is not None:
-                robots_id.append(robot_id)
+        robots_id = self.get_robots_id(robots_vel)
         
+        # 自身のIDを削除
         if is_delete_my_id:
             if is_delete_my_id in robots_id:
-                # 自身のIDを削除
                 robots_id.remove(my_robot_id)
 
         # パサーより前に存在するロボットIDをリスト化


### PR DESCRIPTION
#82 の対策

パス関数起動時にロボットの座標などの値を格納していたが，代入文では元々の変数の値が変化するとその変数の値も変化する

そのため，参照タイミングの違いによって値がある/ないが変わっていました

その対策としてdeepcopyで確定した値を格納しています