### PR TITLE
アタッカーがディフェンスエリアに侵入しないように、ball_in_defence_areaのyを広げた

### DIFF
--- a/consai_examples/consai_examples/field_observer.py
+++ b/consai_examples/consai_examples/field_observer.py
@@ -228,7 +228,7 @@ class FieldObserver(Node):
     def _check_is_ball_in_defense_area(self, ball_pos, our_area=True):
         # ボールがディフェンスエリアに入ったか判定
         threshold_x = self._field_half_x - self._field_defense_x
-        threshold_y = self._field_defense_half_y
+        threshold_y = self._field_defense_half_y + 0.1  # ロボットの半径分マージンをとる
         if self.ball_is_in_our_defense_area() or self.ball_is_in_their_defense_area():
             threshold_x -= self.THRESHOLD_MARGIN
             threshold_y += self.THRESHOLD_MARGIN


### PR DESCRIPTION
ディフェンスエリアにボールが入った判定を広げます

これにより「 Attacker touched ball inside opponent defense area」の発生を防ぎます。

![image](https://user-images.githubusercontent.com/18494952/236091718-ac50a387-bb40-44a5-8c47-4fcfa5f307de.png)

## ルール

- ロボットが部分的にもしくは完全に相手チームのディフェンスエリアにある間、そのロボットはボールに接触してはならない。
