### PR TITLE
サイドウイング追加

### DIFF
--- a/consai_examples/CMakeLists.txt
+++ b/consai_examples/CMakeLists.txt
@@ -38,6 +38,7 @@ install(PROGRAMS
     ${PROJECT_NAME}/decisions/sub_attacker.py
     ${PROJECT_NAME}/decisions/substitute.py
     ${PROJECT_NAME}/decisions/zone_defense.py
+    ${PROJECT_NAME}/decisions/side_wing.py
     DESTINATION lib/${PROJECT_NAME})
 
 install(DIRECTORY

--- a/consai_examples/consai_examples/decisions/side_wing.py
+++ b/consai_examples/consai_examples/decisions/side_wing.py
@@ -46,6 +46,13 @@ class SideWingDecision(DecisionBase):
         p2_y = (1.8 + 0.5) * (-1 if self._wing_id.value > 0 else 1)
         self._operator.move_to_line_to_defend_our_goal(robot_id, p1_x, p1_y, p2_x, p2_y)
 
+    def _defend_our_half_way(self, robot_id):
+        # Half-wayラインの自陣側で待機
+        target_x = -1.0
+        target_y = 4.0 * (-1 if self._wing_id.value > 0 else 1)
+        self._operator.move_to_reflect_shoot_to_their_goal(
+                    robot_id, target_x, target_y)
+
     def _offend_upper_defense_area(self, robot_id):
         # 相手フィールドで待機する
         p1_x = 2.0
@@ -56,7 +63,7 @@ class SideWingDecision(DecisionBase):
 
     def stop(self, robot_id):
         if self._act_id != self.ACT_ID_STOP:
-            self._defend_upper_defense_area(robot_id)
+            self._defend_our_half_way(robot_id)
             self._act_id = self.ACT_ID_STOP
 
     def inplay(self, robot_id):
@@ -67,22 +74,22 @@ class SideWingDecision(DecisionBase):
 
     def our_pre_kickoff(self, robot_id):
         if self._act_id != self.ACT_ID_PRE_KICKOFF:
-            self._defend_upper_defense_area(robot_id)
+            self._defend_our_half_way(robot_id)
             self._act_id = self.ACT_ID_PRE_KICKOFF
 
     def our_kickoff(self, robot_id):
         if self._act_id != self.ACT_ID_KICKOFF:
-            self._defend_upper_defense_area(robot_id)
+            self._defend_our_half_way(robot_id)
             self._act_id = self.ACT_ID_KICKOFF
 
     def their_pre_kickoff(self, robot_id):
         if self._act_id != self.ACT_ID_PRE_KICKOFF:
-            self._defend_upper_defense_area(robot_id)
+            self._defend_our_half_way(robot_id)
             self._act_id = self.ACT_ID_PRE_KICKOFF
 
     def their_kickoff(self, robot_id):
         if self._act_id != self.ACT_ID_KICKOFF:
-            self._defend_upper_defense_area(robot_id)
+            self._defend_our_half_way(robot_id)
             self._act_id = self.ACT_ID_KICKOFF
 
     def our_pre_penalty(self, robot_id):
@@ -117,22 +124,22 @@ class SideWingDecision(DecisionBase):
 
     def our_direct(self, robot_id):
         if self._act_id != self.ACT_ID_DIRECT:
-            self._defend_upper_defense_area(robot_id)
+            self._defend_our_half_way(robot_id)
             self._act_id = self.ACT_ID_DIRECT
 
     def their_direct(self, robot_id):
         if self._act_id != self.ACT_ID_DIRECT:
-            self._defend_upper_defense_area(robot_id)
+            self._defend_our_half_way(robot_id)
             self._act_id = self.ACT_ID_DIRECT
 
     def our_indirect(self, robot_id):
         if self._act_id != self.ACT_ID_INDIRECT:
-            self._defend_upper_defense_area(robot_id)
+            self._defend_our_half_way(robot_id)
             self._act_id = self.ACT_ID_INDIRECT
 
     def their_indirect(self, robot_id):
         if self._act_id != self.ACT_ID_INDIRECT:
-            self._defend_upper_defense_area(robot_id)
+            self._defend_our_half_way(robot_id)
             self._act_id = self.ACT_ID_INDIRECT
 
     def our_ball_placement(self, robot_id, placement_pos):

--- a/consai_examples/consai_examples/decisions/side_wing.py
+++ b/consai_examples/consai_examples/decisions/side_wing.py
@@ -57,13 +57,15 @@ class SideWingDecision(DecisionBase):
         # 相手フィールドで待機する
         p1_x = 2.0
         p1_y = 4.0 * (-1 if self._wing_id.value > 0 else 1)
-        p2_x = 3.0
+        p2_x = 5.0
         p2_y = 4.0 * (-1 if self._wing_id.value > 0 else 1)
-        self._operator.move_to_cross_line_their_center_and_ball_with_reflect(robot_id, p1_x, p1_y, p2_x, p2_y)
+        # self._operator.move_to_cross_line_our_center_and_ball_with_reflect(robot_id, p1_x, p1_y, p2_x, p2_y)
+        self._operator.move_to_cross_line_our_center_and_ball(robot_id, p1_x, p1_y, p2_x, p2_y)
 
     def stop(self, robot_id):
         if self._act_id != self.ACT_ID_STOP:
-            self._defend_our_half_way(robot_id)
+            # self._defend_our_half_way(robot_id)
+            self._offend_upper_defense_area(robot_id)
             self._act_id = self.ACT_ID_STOP
 
     def inplay(self, robot_id):

--- a/consai_examples/consai_examples/decisions/side_wing.py
+++ b/consai_examples/consai_examples/decisions/side_wing.py
@@ -41,17 +41,17 @@ class SideWingDecision(DecisionBase):
     def _defend_upper_defense_area(self, robot_id):
         # ディフェンスエリアの外側を守る
         p1_x = -6.0 + 0.3
-        p1_y = (1.8 + 0.5) * (-1 * self._wing_id.value)
+        p1_y = (1.8 + 0.5) * (-1 if self._wing_id.value > 0 else 1)
         p2_x = -6.0 + 1.8 + 0.3
-        p2_y = (1.8 + 0.5) * (-1 * self._wing_id.value)
+        p2_y = (1.8 + 0.5) * (-1 if self._wing_id.value > 0 else 1)
         self._operator.move_to_line_to_defend_our_goal(robot_id, p1_x, p1_y, p2_x, p2_y)
 
     def _offend_upper_defense_area(self, robot_id):
         # 相手フィールドで待機する
         p1_x = 2.0
-        p1_y = 4.0 * (-1 * self._wing_id.value)
+        p1_y = 4.0 * (-1 if self._wing_id.value > 0 else 1)
         p2_x = 3.0
-        p2_y = 4.0 * (-1 * self._wing_id.value)
+        p2_y = 4.0 * (-1 if self._wing_id.value > 0 else 1)
         self._operator.move_to_cross_line_their_center_and_ball_with_reflect(robot_id, p1_x, p1_y, p2_x, p2_y)
 
     def stop(self, robot_id):

--- a/consai_examples/consai_examples/decisions/side_wing.py
+++ b/consai_examples/consai_examples/decisions/side_wing.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# coding: UTF-8
+
+# Copyright 2023 Roots
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from enum import Enum
+
+from decisions.decision_base import DecisionBase
+from field_observer import FieldObserver
+
+class WingID(Enum):
+    LEFT = 0
+    RIGHT = 1
+
+
+class SideWingDecision(DecisionBase):
+
+    def __init__(self, robot_operator, field_observer, wing_id: WingID):
+        super().__init__(robot_operator, field_observer)
+        self._wing_id = wing_id
+        self._our_penalty_pos_x = -6.0 + 0.5
+        self._our_penalty_pos_y = 4.5 - 0.3 * (3.0 + self._wing_id.value)
+        self._their_penalty_pos_x = 6.0 - 0.5
+        self._their_penalty_pos_y = 4.5 - 0.3 * (3.0 + self._wing_id.value)
+        self._ball_placement_pos_x = -6.0 + 2.0
+        self._ball_placement_pos_y = 1.8 - 0.3 * (8.0 + self._wing_id.value)
+
+    def _defend_upper_defense_area(self, robot_id):
+        # ディフェンスエリアの外側を守る
+        p1_x = -6.0 + 0.3
+        p1_y = (1.8 + 0.5) * (-1 * self._wing_id.value)
+        p2_x = -6.0 + 1.8 + 0.3
+        p2_y = (1.8 + 0.5) * (-1 * self._wing_id.value)
+        self._operator.move_to_line_to_defend_our_goal(robot_id, p1_x, p1_y, p2_x, p2_y)
+
+    def _offend_upper_defense_area(self, robot_id):
+        # 相手フィールドで待機する
+        p1_x = 2.0
+        p1_y = 4.0 * (-1 * self._wing_id.value)
+        p2_x = 3.0
+        p2_y = 4.0 * (-1 * self._wing_id.value)
+        self._operator.move_to_cross_line_their_center_and_ball_with_reflect(robot_id, p1_x, p1_y, p2_x, p2_y)
+
+    def stop(self, robot_id):
+        if self._act_id != self.ACT_ID_STOP:
+            self._defend_upper_defense_area(robot_id)
+            self._act_id = self.ACT_ID_STOP
+
+    def inplay(self, robot_id):
+        if self._act_id != self.ACT_ID_INPLAY:
+            self._offend_upper_defense_area(robot_id)
+            # self._defend_upper_defense_area(robot_id)
+            self._act_id = self.ACT_ID_INPLAY
+
+    def our_pre_kickoff(self, robot_id):
+        if self._act_id != self.ACT_ID_PRE_KICKOFF:
+            self._defend_upper_defense_area(robot_id)
+            self._act_id = self.ACT_ID_PRE_KICKOFF
+
+    def our_kickoff(self, robot_id):
+        if self._act_id != self.ACT_ID_KICKOFF:
+            self._defend_upper_defense_area(robot_id)
+            self._act_id = self.ACT_ID_KICKOFF
+
+    def their_pre_kickoff(self, robot_id):
+        if self._act_id != self.ACT_ID_PRE_KICKOFF:
+            self._defend_upper_defense_area(robot_id)
+            self._act_id = self.ACT_ID_PRE_KICKOFF
+
+    def their_kickoff(self, robot_id):
+        if self._act_id != self.ACT_ID_KICKOFF:
+            self._defend_upper_defense_area(robot_id)
+            self._act_id = self.ACT_ID_KICKOFF
+
+    def our_pre_penalty(self, robot_id):
+        if self._act_id != self.ACT_ID_PRE_PENALTY:
+            self._operator.move_to_look_ball(robot_id, self._our_penalty_pos_x, self._our_penalty_pos_y)
+            self._act_id = self.ACT_ID_PRE_PENALTY
+
+    def our_penalty(self, robot_id):
+        if self._act_id != self.ACT_ID_PENALTY:
+            self._operator.move_to_look_ball(robot_id, self._our_penalty_pos_x, self._our_penalty_pos_y)
+            self._act_id = self.ACT_ID_PENALTY
+
+    def their_pre_penalty(self, robot_id):
+        if self._act_id != self.ACT_ID_PRE_PENALTY:
+            self._operator.move_to_look_ball(robot_id, self._their_penalty_pos_x, self._their_penalty_pos_y)
+            self._act_id = self.ACT_ID_PRE_PENALTY
+
+    def their_penalty(self, robot_id):
+        if self._act_id != self.ACT_ID_PENALTY:
+            self._operator.move_to_look_ball(robot_id, self._their_penalty_pos_x, self._their_penalty_pos_y)
+            self._act_id = self.ACT_ID_PENALTY
+
+    def our_penalty_inplay(self, robot_id):
+        if self._act_id != self.ACT_ID_INPLAY:
+            self._operator.stop(robot_id)
+            self._act_id = self.ACT_ID_INPLAY
+
+    def their_penalty_inplay(self, robot_id):
+        if self._act_id != self.ACT_ID_INPLAY:
+            self._operator.stop(robot_id)
+            self._act_id = self.ACT_ID_INPLAY
+
+    def our_direct(self, robot_id):
+        if self._act_id != self.ACT_ID_DIRECT:
+            self._defend_upper_defense_area(robot_id)
+            self._act_id = self.ACT_ID_DIRECT
+
+    def their_direct(self, robot_id):
+        if self._act_id != self.ACT_ID_DIRECT:
+            self._defend_upper_defense_area(robot_id)
+            self._act_id = self.ACT_ID_DIRECT
+
+    def our_indirect(self, robot_id):
+        if self._act_id != self.ACT_ID_INDIRECT:
+            self._defend_upper_defense_area(robot_id)
+            self._act_id = self.ACT_ID_INDIRECT
+
+    def their_indirect(self, robot_id):
+        if self._act_id != self.ACT_ID_INDIRECT:
+            self._defend_upper_defense_area(robot_id)
+            self._act_id = self.ACT_ID_INDIRECT
+
+    def our_ball_placement(self, robot_id, placement_pos):
+        if self._act_id != self.ACT_ID_OUR_PLACEMENT:
+            self._operator.move_to_look_ball(robot_id, self._ball_placement_pos_x, self._ball_placement_pos_y)
+            self._act_id = self.ACT_ID_OUR_PLACEMENT
+
+    def their_ball_placement(self, robot_id, placement_pos):
+        if self._act_id != self.ACT_ID_THEIR_PLACEMENT:
+            self._operator.move_to_look_ball(robot_id, self._ball_placement_pos_x, self._ball_placement_pos_y)
+            self._act_id = self.ACT_ID_THEIR_PLACEMENT

--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -27,10 +27,10 @@ from decisions.decision_base import DecisionBase
 from decisions.goalie import GoaleDecision
 from decisions.side_back1 import SideBack1Decision
 from decisions.side_back2 import SideBack2Decision
+from decisions.side_wing import SideWingDecision, WingID
 from decisions.sub_attacker import SubAttackerDecision
 from decisions.substitute import SubstituteDecision
-from decisions.zone_defense import ZoneDefenseDecision
-from decisions.zone_defense import ZoneDefenseID
+from decisions.zone_defense import ZoneDefenseDecision, ZoneDefenseID
 from field_observer import FieldObserver
 from rclpy.executors import MultiThreadedExecutor
 from referee_parser import RefereeParser
@@ -214,6 +214,8 @@ if __name__ == '__main__':
         RoleName.ZONE4: ZoneDefenseDecision(operator, observer, ZoneDefenseID.ZONE4),
         RoleName.SIDE_BACK1: SideBack1Decision(operator, observer),
         RoleName.SIDE_BACK2: SideBack2Decision(operator, observer),
+        RoleName.LEFT_WING: SideWingDecision(operator, observer, WingID.LEFT),
+        RoleName.RIGHT_WING: SideWingDecision(operator, observer, WingID.RIGHT),
         RoleName.SUBSTITUTE: SubstituteDecision(operator, observer, args.invert),
     }
 

--- a/consai_examples/consai_examples/robot_operator.py
+++ b/consai_examples/consai_examples/robot_operator.py
@@ -288,6 +288,35 @@ class RobotOperator(Node):
         line.theta = self._theta_look_ball()
         target = self._xy_their_goal()
         return self._set_goal(robot_id, self._with_reflect_kick(self._line_goal(line, keep=True), target, kick_pass=False))
+    
+    def move_to_cross_line_our_center_and_ball(self, robot_id, p1_x, p1_y, p2_x, p2_y):
+        # 直線p1->p2と
+        # 自分サイドの中心とボールを結ぶ直線が交差する点で、ボールを見る
+        line = ConstraintLine()
+
+        # 直線p1->p2を作成
+        line.p1 = self._xy(p1_x, p1_y)
+        line.p2 = self._xy(p2_x, p2_y)
+
+        line.p3.append(self._xy_our_side_center())
+        line.p4.append(self._xy_object_ball())
+        line.theta = self._theta_look_ball()
+        return self._set_goal(robot_id, self._with_receive(self._line_goal(line, keep=True)))
+
+    def move_to_cross_line_our_center_and_ball_with_reflect(self, robot_id, p1_x, p1_y, p2_x, p2_y):
+        # 直線p1->p2と
+        # 自分サイドの中心とボールを結ぶ直線が交差する点で、ボールを見る
+        line = ConstraintLine()
+
+        # 直線p1->p2を作成
+        line.p1 = self._xy(p1_x, p1_y)
+        line.p2 = self._xy(p2_x, p2_y)
+
+        line.p3.append(self._xy_our_side_center())
+        line.p4.append(self._xy_object_ball())
+        line.theta = self._theta_look_ball()
+        target = self._xy_their_goal()
+        return self._set_goal(robot_id, self._with_reflect_kick(self._line_goal(line, keep=True), target, kick_pass=False))
 
     def move_to_defend_our_goal_from_ball(self, robot_id, distance):
         # 自チームのゴールとボールを結び、ボールからdistanceだけ離れた位置に移動する
@@ -639,6 +668,14 @@ class RobotOperator(Node):
         their_center = ConstraintXY()
         their_center.normalized = True
         their_center.value_x.append(0.5)
+        their_center.value_y.append(0.0)
+        return their_center
+    
+    def _xy_our_side_center(self):
+        # ConstraintXYの自分サイドの中央を返す
+        their_center = ConstraintXY()
+        their_center.normalized = True
+        their_center.value_x.append(-0.5)
         their_center.value_y.append(0.0)
         return their_center
 

--- a/consai_examples/consai_examples/role_assignment.py
+++ b/consai_examples/consai_examples/role_assignment.py
@@ -42,7 +42,9 @@ class RoleName(Enum):
     ZONE4 = 8
     SIDE_BACK1 = 9
     SIDE_BACK2 = 10
-    SUBSTITUTE = 11
+    LEFT_WING = 11
+    RIGHT_WING = 12
+    SUBSTITUTE = 13
 
 
 # フィールド状況を見て、ロボットの役割を決めるノード
@@ -74,8 +76,10 @@ class RoleAssignment(Node):
             RoleName.ZONE2,
             RoleName.ZONE3,
             RoleName.ZONE4,
-            RoleName.SIDE_BACK1,
-            RoleName.SIDE_BACK2,
+            # RoleName.SIDE_BACK1,
+            # RoleName.SIDE_BACK2,
+            RoleName.LEFT_WING,
+            RoleName.RIGHT_WING,
         ]
         # 実際に運用するroleのリスト
         # イエローカードや交代指示などで役割が変更されます


### PR DESCRIPTION
# やったこと

- side backをベースにside wing追加
- zoneDFと同じように1ファイルで管理
- stop中の待機場所をzoneDFの前くらいに移動
- オフェンスの位置取りを自陣のセンターとボールの延長線上に位置するようにした
    - ![wingの動き説明](https://user-images.githubusercontent.com/38589340/236126569-502c4201-10d1-4dcf-bc93-b41e9227f371.png)
    - ![wingの動き説明2](https://user-images.githubusercontent.com/38589340/236126594-96cfb627-6c66-4704-b763-af03810c5dd3.png)
- リフレクトシュート関数にするとボールをとりにいく角度が限られるのでリフレクトシュートじゃないほうにした

# やらないこと

- 位置取りの修正などは試合で見ながら