### PR TITLE
goal_poses型を作って、goal_poseとfinal_goal_poseを集約した

### DIFF
--- a/consai_msgs/CMakeLists.txt
+++ b/consai_msgs/CMakeLists.txt
@@ -28,6 +28,7 @@ set(msg_files
   "msg/ConstraintTheta.msg"
   "msg/ConstraintXY.msg"
   "msg/GoalPose.msg"
+  "msg/GoalPoses.msg"
   "msg/NamedTargets.msg"
   "msg/ParsedReferee.msg"
   "msg/RobotLocalVelocities.msg"

--- a/consai_msgs/msg/GoalPoses.msg
+++ b/consai_msgs/msg/GoalPoses.msg
@@ -1,0 +1,3 @@
+# Controllerが出力する目標姿勢のリスト
+
+GoalPose[] poses

--- a/consai_robot_controller/include/consai_robot_controller/controller_component.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/controller_component.hpp
@@ -15,6 +15,7 @@
 #ifndef CONSAI_ROBOT_CONTROLLER__CONTROLLER_COMPONENT_HPP_
 #define CONSAI_ROBOT_CONTROLLER__CONTROLLER_COMPONENT_HPP_
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -23,6 +24,7 @@
 #include "consai_frootspi_msgs/msg/robot_command.hpp"
 #include "consai_msgs/action/robot_control.hpp"
 #include "consai_msgs/msg/goal_pose.hpp"
+#include "consai_msgs/msg/goal_poses.hpp"
 #include "consai_msgs/msg/named_targets.hpp"
 #include "consai_msgs/msg/parsed_referee.hpp"
 #include "consai_msgs/msg/state2_d.hpp"
@@ -38,6 +40,7 @@
 namespace consai_robot_controller
 {
 using GoalPose = consai_msgs::msg::GoalPose;
+using GoalPoses = consai_msgs::msg::GoalPoses;
 using NamedTargets = consai_msgs::msg::NamedTargets;
 using State = consai_msgs::msg::State2D;
 using RobotCommand = consai_frootspi_msgs::msg::RobotCommand;
@@ -48,7 +51,7 @@ using ParsedReferee = consai_msgs::msg::ParsedReferee;
 using Referee = robocup_ssl_msgs::msg::Referee;
 using TrackedFrame = robocup_ssl_msgs::msg::TrackedFrame;
 using TrackedRobot = robocup_ssl_msgs::msg::TrackedRobot;
-
+using GoalPosesMap = std::map<unsigned int, GoalPose>;
 
 class Controller : public rclcpp::Node
 {
@@ -59,6 +62,7 @@ public:
 protected:
   void on_timer_pub_control_command(const unsigned int robot_id);
   void on_timer_pub_stop_command(const unsigned int robot_id);
+  void on_timer_pub_goal_poses();
 
 private:
   void callback_detection_tracked(const TrackedFrame::SharedPtr msg);
@@ -89,8 +93,6 @@ private:
     const unsigned int robot_id, const bool success, const std::string & error_msg);
 
   std::vector<rclcpp::Publisher<RobotCommand>::SharedPtr> pub_command_;
-  std::vector<rclcpp::Publisher<GoalPose>::SharedPtr> pub_goal_pose_;
-  std::vector<rclcpp::Publisher<GoalPose>::SharedPtr> pub_final_goal_pose_;
   std::vector<rclcpp_action::Server<RobotControl>::SharedPtr> server_control_;
   std::vector<rclcpp::Time> last_update_time_;
   std::vector<std::shared_ptr<control_toolbox::Pid>> pid_vx_;
@@ -109,6 +111,11 @@ private:
   rclcpp::Subscription<NamedTargets>::SharedPtr sub_named_targets_;
   rclcpp::Subscription<Referee>::SharedPtr sub_referee_;
   rclcpp::Subscription<ParsedReferee>::SharedPtr sub_parsed_referee_;
+  rclcpp::Publisher<GoalPoses>::SharedPtr pub_goal_poses_;
+  rclcpp::Publisher<GoalPoses>::SharedPtr pub_final_goal_poses_;
+  rclcpp::TimerBase::SharedPtr timer_pub_goal_poses_;
+  GoalPosesMap goal_poses_map_;
+  GoalPosesMap final_goal_poses_map_;
   bool team_is_yellow_;
   rclcpp::Clock steady_clock_;
   OnSetParametersCallbackHandle::SharedPtr handler_change_param_;

--- a/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
@@ -73,6 +73,8 @@ public:
     const std::shared_ptr<const RobotControl::Goal> goal,
     const TrackedRobot & my_robot, State & parsed_pose, State & final_goal_pose,
     double & kick_power, double & dribble_power) const;
+  std::vector<unsigned int> active_robot_id_list(const bool team_is_yellow) const;
+
 private:
   bool parse_constraint_pose(const ConstraintPose & pose, State & parsed_pose) const;
   bool parse_constraint_line(const ConstraintLine & line, State & parsed_pose) const;

--- a/consai_robot_controller/src/controller_component.cpp
+++ b/consai_robot_controller/src/controller_component.cpp
@@ -78,15 +78,6 @@ Controller::Controller(const rclcpp::NodeOptions & options)
       create_publisher<RobotCommand>(
         "robot" + std::to_string(i) + "/command", 10)
     );
-    pub_goal_pose_.push_back(
-      create_publisher<GoalPose>(
-        "robot" + std::to_string(i) + "/goal_pose", 10)
-    );
-
-    pub_final_goal_pose_.push_back(
-      create_publisher<GoalPose>(
-        "robot" + std::to_string(i) + "/final_goal_pose", 10)
-    );
 
     std::string name_space = team_color + std::to_string(i);
     server_control_.push_back(
@@ -154,6 +145,10 @@ Controller::Controller(const rclcpp::NodeOptions & options)
     need_response_.push_back(false);
   }
   goal_handle_.resize(ROBOT_NUM);
+
+  pub_goal_poses_ = create_publisher<GoalPoses>("goal_poses", 10);
+  pub_final_goal_poses_ = create_publisher<GoalPoses>("final_goal_poses", 10);
+  timer_pub_goal_poses_ = create_wall_timer(10ms, std::bind(&Controller::on_timer_pub_goal_poses, this));
 
   sub_detection_tracked_ = create_subscription<TrackedFrame>(
     "detection_tracked", 10, std::bind(&Controller::callback_detection_tracked, this, _1));
@@ -294,17 +289,17 @@ void Controller::on_timer_pub_control_command(const unsigned int robot_id)
   last_world_vel_[robot_id] = world_vel;
 
   // ビジュアライズ用に、目標姿勢と最終目標姿勢を出力する
-  auto goal_pose_msg = std::make_unique<GoalPose>();
-  auto final_goal_pose_msg = std::make_unique<GoalPose>();
-  goal_pose_msg->robot_id = robot_id;
-  goal_pose_msg->team_is_yellow = team_is_yellow_;
-  goal_pose_msg->pose = goal_pose;
-  pub_goal_pose_[robot_id]->publish(std::move(goal_pose_msg));
+  GoalPose goal_pose_msg;
+  goal_pose_msg.robot_id = robot_id;
+  goal_pose_msg.team_is_yellow = team_is_yellow_;
+  goal_pose_msg.pose = goal_pose;
+  goal_poses_map_[robot_id] = goal_pose_msg;
 
-  final_goal_pose_msg->robot_id = robot_id;
-  final_goal_pose_msg->team_is_yellow = team_is_yellow_;
-  final_goal_pose_msg->pose = final_goal_pose;
-  pub_final_goal_pose_[robot_id]->publish(std::move(final_goal_pose_msg));
+  GoalPose final_goal_pose_msg;
+  final_goal_pose_msg.robot_id = robot_id;
+  final_goal_pose_msg.team_is_yellow = team_is_yellow_;
+  final_goal_pose_msg.pose = final_goal_pose;
+  final_goal_poses_map_[robot_id] = final_goal_pose_msg;
 
   // 途中経過を報告する
   if (need_response_[robot_id]) {
@@ -350,6 +345,22 @@ void Controller::on_timer_pub_stop_command(const unsigned int robot_id)
     timer_pub_stop_command_[robot_id]->cancel();
     timer_pub_control_command_[robot_id]->reset();
   }
+}
+
+void Controller::on_timer_pub_goal_poses()
+{
+  // goal_posesをpublishするタイマーコールバック関数
+  auto goal_poses = std::make_unique<GoalPoses>();
+  for (const auto & goal_pose : goal_poses_map_) {
+    goal_poses->poses.push_back(goal_pose.second);
+  }
+  pub_goal_poses_->publish(std::move(goal_poses));
+
+  auto final_goal_poses = std::make_unique<GoalPoses>();
+  for (const auto & goal_pose : final_goal_poses_map_) {
+    final_goal_poses->poses.push_back(goal_pose.second);
+  }
+  pub_final_goal_poses_->publish(std::move(final_goal_poses));
 }
 
 void Controller::callback_detection_tracked(const TrackedFrame::SharedPtr msg)

--- a/consai_robot_controller/src/controller_component.cpp
+++ b/consai_robot_controller/src/controller_component.cpp
@@ -351,15 +351,16 @@ void Controller::on_timer_pub_goal_poses()
 {
   // goal_posesをpublishするタイマーコールバック関数
   auto goal_poses = std::make_unique<GoalPoses>();
-  for (const auto & goal_pose : goal_poses_map_) {
-    goal_poses->poses.push_back(goal_pose.second);
+  auto final_goal_poses = std::make_unique<GoalPoses>();
+  for(const auto & robot_id : parser_.active_robot_id_list(team_is_yellow_)) {
+    if (goal_poses_map_.count(robot_id) > 0) {
+      goal_poses->poses.push_back(goal_poses_map_[robot_id]);
+    }
+    if (final_goal_poses_map_.count(robot_id) > 0) {
+      final_goal_poses->poses.push_back(final_goal_poses_map_[robot_id]);
+    }
   }
   pub_goal_poses_->publish(std::move(goal_poses));
-
-  auto final_goal_poses = std::make_unique<GoalPoses>();
-  for (const auto & goal_pose : final_goal_poses_map_) {
-    final_goal_poses->poses.push_back(goal_pose.second);
-  }
   pub_final_goal_poses_->publish(std::move(final_goal_poses));
 }
 

--- a/consai_visualizer/src/consai_visualizer/field_widget.py
+++ b/consai_visualizer/src/consai_visualizer/field_widget.py
@@ -127,11 +127,13 @@ class FieldWidget(QWidget):
     def set_detection_tracked(self, msg):
         self._detection_tracked = msg
 
-    def set_goal_pose(self, msg, robot_id):
-        self._goal_poses[robot_id] = msg
+    def set_goal_poses(self, msg):
+        for goal_pose in msg.poses:
+            self._goal_poses[goal_pose.robot_id] = goal_pose
 
-    def set_final_goal_pose(self, msg, robot_id):
-        self._final_goal_poses[robot_id] = msg
+    def set_final_goal_poses(self, msg):
+        for goal_pose in msg.poses:
+            self._final_goal_poses[goal_pose.robot_id] = goal_pose
 
     def set_designated_position(self, msg):
         self._designated_position[0] = msg

--- a/consai_visualizer/src/consai_visualizer/field_widget.py
+++ b/consai_visualizer/src/consai_visualizer/field_widget.py
@@ -128,10 +128,12 @@ class FieldWidget(QWidget):
         self._detection_tracked = msg
 
     def set_goal_poses(self, msg):
+        self._goal_poses.clear()
         for goal_pose in msg.poses:
             self._goal_poses[goal_pose.robot_id] = goal_pose
 
     def set_final_goal_poses(self, msg):
+        self._final_goal_poses.clear()
         for goal_pose in msg.poses:
             self._final_goal_poses[goal_pose.robot_id] = goal_pose
 

--- a/consai_visualizer/src/consai_visualizer/visualizer.py
+++ b/consai_visualizer/src/consai_visualizer/visualizer.py
@@ -19,7 +19,7 @@ from functools import partial
 import os
 
 from ament_index_python.resources import get_resource
-from consai_msgs.msg import GoalPose
+from consai_msgs.msg import GoalPoses
 from consai_msgs.msg import NamedTargets
 from consai_visualizer.field_widget import FieldWidget
 import consai_visualizer.referee_parser as ref_parser
@@ -79,17 +79,10 @@ class Visualizer(Plugin):
             NamedTargets, 'named_targets',
             self._widget.field_widget.set_named_targets, 10)
 
-        self._sub_goal_pose = []
-        self._sub_final_goal_pose = []
-        for i in range(16):
-            topic_name = 'robot' + str(i) + '/goal_pose'
-            self._sub_goal_pose.append(self._node.create_subscription(
-                GoalPose, topic_name,
-                partial(self._widget.field_widget.set_goal_pose, robot_id=i), 10))
-            topic_name = 'robot' + str(i) + '/final_goal_pose'
-            self._sub_final_goal_pose.append(self._node.create_subscription(
-                GoalPose, topic_name,
-                partial(self._widget.field_widget.set_final_goal_pose, robot_id=i), 10))
+        self._sub_goal_poses = self._node.create_subscription(
+                GoalPoses, 'goal_poses', self._widget.field_widget.set_goal_poses, 10)
+        self._sub_final_goal_poses = self._node.create_subscription(
+                GoalPoses, 'final_goal_poses', self._widget.field_widget.set_final_goal_poses, 10)
 
         self._widget.field_widget.set_pub_replacement(
             self._node.create_publisher(Replacement, 'replacement', 1))


### PR DESCRIPTION
#88 でfinal_goal_poseトピックを登場させましたが、トピック数がロボット台数分多くなり、処理が重くなりました。

`goal_poses`と`final_goal_poses`にトピックを集約し、処理を軽くします。