### PR TITLE
refere_parserにforce_startフラグを追加

### DIFF
--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -108,7 +108,7 @@ def main():
                 decisions[role].enable_stop_game_velocity(robot_id)
                 decisions[role].stop(robot_id)
                 decisions[role].disable_stop_game_velocity(robot_id)
-            elif referee.inplay():
+            elif referee.inplay() or referee.force_start():
                 decisions[role].inplay(robot_id)
             elif referee.our_pre_kickoff():
                 decisions[role].our_pre_kickoff(robot_id)
@@ -167,7 +167,7 @@ def main():
                 decisions[role].their_ball_placement(
                     robot_id, referee.placement_position())
             else:
-                print("UNDEFINED REFEREE COMMAND!!!")
+                print("UNDEFINED REFEREE COMMAND!!! : {}".format(referee.get_command()))
 
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()

--- a/consai_examples/consai_examples/referee_parser.py
+++ b/consai_examples/consai_examples/referee_parser.py
@@ -224,6 +224,9 @@ class RefereeParser(Node):
     def inplay(self):
         return self._current_command == self._COMMAND_INPLAY
 
+    def force_start(self):
+        return self._current_command == Referee.COMMAND_FORCE_START
+
     def our_penalty_inplay(self):
         return self._current_command == self._COMMAND_OUR_PENALTY_INPLAY
 


### PR DESCRIPTION
refereeがFORCE_STARTを発行したとき、game.pyで"UNDEFINED REFEREE COMMAND" と出力されていました。

force_startフラグを追加して解決します。

game.pyにて、force_start時はinplay()動作を実行します。