### PR TITLE
grSimのボールを動かすとき、ボールが弾け飛ぶのを解決する

### DIFF
--- a/consai_visualizer/src/consai_visualizer/field_widget.py
+++ b/consai_visualizer/src/consai_visualizer/field_widget.py
@@ -307,6 +307,8 @@ class FieldWidget(QWidget):
         pos = self._convert_draw_to_field_pos(self._mouse_current_point)
         ball_replacement.x.append(pos.x() * 0.001)  # mm に変換
         ball_replacement.y.append(pos.y() * 0.001)  # mm に変換
+        ball_replacement.vx.append(0.0)
+        ball_replacement.vy.append(0.0)
         replacement = Replacement()
         replacement.ball.append(ball_replacement)
         self._pub_replacement.publish(replacement)


### PR DESCRIPTION

GUIでgrsimのボールを動かすとき、ボールが弾け飛ぶ問題を解決します。

再配置時の速度を0にすることで解決しました。
![image](https://user-images.githubusercontent.com/18494952/236233219-e4cd83f1-9e8a-4961-ba7b-d18d7a342fd7.png)

