### PR TITLE
アタッカーの不要な切り替わりを防ぐ

### DIFF
--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -53,6 +53,8 @@ def enable_update_attacker_by_ball_pos():
     return not observer.ball_is_in_our_defense_area() and \
         not observer.ball_is_outside_back_x() and \
         not observer.ball_is_outside_front_x() and \
+        not observer.ball_is_outside_right_y() and \
+        not observer.ball_is_outside_left_y() and \
         not observer.ball_is_moving() and \
         not referee.our_ball_placement() and \
         not referee.our_pre_penalty() and \

--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -52,6 +52,7 @@ def enable_update_attacker_by_ball_pos():
     # ボールが動いてたり、ディフェンスエリアや自ゴール側場外にあるときは役割を更新しない
     return not observer.ball_is_in_our_defense_area() and \
         not observer.ball_is_outside_back_x() and \
+        not observer.ball_is_outside_front_x() and \
         not observer.ball_is_moving() and \
         not referee.our_ball_placement() and \
         not referee.our_pre_penalty() and \


### PR DESCRIPTION
フィールドの外だったらアタッカー切り替えません