### PR TITLE
ConstraintLineに交点からのオフセットを追加

### DIFF
--- a/consai_examples/consai_examples/control.py
+++ b/consai_examples/consai_examples/control.py
@@ -275,6 +275,9 @@ def test_move_to_line():
             pass
 
 def test_defend_goal_on_line(p1_x, p1_y, p2_x, p2_y):
+    print("test_use_named_targets")
+    time.sleep(1.0)  # operatorの起動を待つ
+
     robot_harf_width = 0.09
     harf_width = 6.0
     defence_harf_width = 0.9
@@ -283,7 +286,7 @@ def test_defend_goal_on_line(p1_x, p1_y, p2_x, p2_y):
     # 0番はキーパの位置に
     x = harf_width - robot_harf_width
     y = goal_harf_height
-    operator_node.move_to_line_to_defend_our_goal(0, -x, y, -x, -y, True)
+    operator_node.move_to_line_to_defend_our_goal(0, -x, y, -x, -y)
     # 1番はディフェンスエリアの上左側に
     # 2番はディフェンスエリアの上右側に
     y = defence_harf_height + robot_harf_width
@@ -291,13 +294,14 @@ def test_defend_goal_on_line(p1_x, p1_y, p2_x, p2_y):
     end_x = harf_width - defence_harf_width
     middle_x = harf_width - defence_harf_width - robot_harf_width * 2.0
     middle_end_x = harf_width - defence_harf_width * 2.0 - robot_harf_width
-    operator_node.move_to_line_to_defend_our_goal(1, -x, y, -end_x, y, True)
-    operator_node.move_to_line_to_defend_our_goal(2, -middle_x, y, -middle_end_x, y, True)
+    # offset_to_p2をセットすると、交点からオフセットできる
+    operator_node.move_to_line_to_defend_our_goal(1, -x, y, -end_x, y, offset_to_p2=-0.5)
+    operator_node.move_to_line_to_defend_our_goal(2, -middle_x, y, -middle_end_x, y, offset_to_p2=-0.5)
 
     # 3番はディフェンスエリアの下左側に
     # 4番はディフェンスエリアの下右側に
-    operator_node.move_to_line_to_defend_our_goal(3, -x, -y, -end_x, -y, True)
-    operator_node.move_to_line_to_defend_our_goal(4, -middle_x, -y, -middle_end_x, -y, True)
+    operator_node.move_to_line_to_defend_our_goal(3, -x, -y, -end_x, -y)
+    operator_node.move_to_line_to_defend_our_goal(4, -middle_x, -y, -middle_end_x, -y)
 
     # 5番はディフェンスエリアの正面上側に
     # 6番はディフェンスエリアの正面上側に
@@ -308,10 +312,10 @@ def test_defend_goal_on_line(p1_x, p1_y, p2_x, p2_y):
     end_y = defence_harf_height * 0.5
     middle_y = defence_harf_height * 0.5 - robot_harf_width * 2.0
     middle_end_y = robot_harf_width
-    operator_node.move_to_line_to_defend_our_goal(5, -x, y, -x, end_y, True)
-    operator_node.move_to_line_to_defend_our_goal(6, -x, middle_y, -x, middle_end_y, True)
-    operator_node.move_to_line_to_defend_our_goal(7, -x, -y, -x, -end_y, True)
-    operator_node.move_to_line_to_defend_our_goal(8, -x, -middle_y, -x, -middle_end_y, True)
+    operator_node.move_to_line_to_defend_our_goal(5, -x, y, -x, end_y)
+    operator_node.move_to_line_to_defend_our_goal(6, -x, middle_y, -x, middle_end_y)
+    operator_node.move_to_line_to_defend_our_goal(7, -x, -y, -x, -end_y)
+    operator_node.move_to_line_to_defend_our_goal(8, -x, -middle_y, -x, -middle_end_y)
 
 def test_reflect_shoot(robot_id, x, y):
     operator_node.move_to_reflect_shoot_to_their_goal(robot_id, x, y)
@@ -479,11 +483,11 @@ def main():
     # test_pass_four_robots()
     # test_stop_robots()
     # test_move_to_line()
-    # test_defend_goal_on_line(-1.0, 1.0, -1.0, -1.0)
+    test_defend_goal_on_line(-1.0, 1.0, -1.0, -1.0)
     # test_reflect_shoot(0, 0, 0)
     # test_refelect_shoot_four_robots(0, 1, 2, 3)
     # test_use_named_targets()
-    test_star_pass()
+    # test_star_pass()
 
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()

--- a/consai_examples/consai_examples/robot_operator.py
+++ b/consai_examples/consai_examples/robot_operator.py
@@ -230,7 +230,7 @@ class RobotOperator(Node):
         pose.theta = self._theta_look_ball()
         return self._set_goal(robot_id, self._with_receive(self._pose_goal(pose, keep=True)))
 
-    def move_to_line_to_defend_our_goal(self, robot_id, p1_x, p1_y, p2_x, p2_y):
+    def move_to_line_to_defend_our_goal(self, robot_id, p1_x, p1_y, p2_x, p2_y, offset_to_p2=None):
         # 自チームのゴールをボールから守るように、直線p1->p2に移動する
         line = ConstraintLine()
 
@@ -242,9 +242,11 @@ class RobotOperator(Node):
         line.p3.append(self._xy_our_goal())
         line.p4.append(self._xy_object_ball())
         line.theta = self._theta_look_ball()
+        if offset_to_p2 is not None:
+            line.offset_intersection_to_p2.append(offset_to_p2)
         return self._set_goal(robot_id, self._with_receive(self._line_goal(line, keep=True)))
 
-    def move_to_line_to_defend_our_goal_with_reflect(self, robot_id, p1_x, p1_y, p2_x, p2_y):
+    def move_to_line_to_defend_our_goal_with_reflect(self, robot_id, p1_x, p1_y, p2_x, p2_y, offset_to_p2=None):
         # 自チームのゴールをボールから守るように、直線p1->p2に移動する
         line = ConstraintLine()
 
@@ -256,11 +258,13 @@ class RobotOperator(Node):
         line.p3.append(self._xy_our_goal())
         line.p4.append(self._xy_object_ball())
         line.theta = self._theta_look_ball()
+        if offset_to_p2:
+            line.offset_intersection_to_p2.append(offset_to_p2)
 
         target = self._xy_their_goal()
         return self._set_goal(robot_id, self._with_reflect_kick(self._line_goal(line, keep=True), target, kick_pass=False))
 
-    def move_to_cross_line_their_center_and_ball(self, robot_id, p1_x, p1_y, p2_x, p2_y):
+    def move_to_cross_line_their_center_and_ball(self, robot_id, p1_x, p1_y, p2_x, p2_y, offset_to_p2=None):
         # 直線p1->p2と
         # 相手サイドの中心とボールを結ぶ直線が交差する点で、ボールを見る
         line = ConstraintLine()
@@ -272,9 +276,12 @@ class RobotOperator(Node):
         line.p3.append(self._xy_their_side_center())
         line.p4.append(self._xy_object_ball())
         line.theta = self._theta_look_ball()
+        if offset_to_p2:
+            line.offset_intersection_to_p2.append(offset_to_p2)
+
         return self._set_goal(robot_id, self._with_receive(self._line_goal(line, keep=True)))
 
-    def move_to_cross_line_their_center_and_ball_with_reflect(self, robot_id, p1_x, p1_y, p2_x, p2_y):
+    def move_to_cross_line_their_center_and_ball_with_reflect(self, robot_id, p1_x, p1_y, p2_x, p2_y, offset_to_p2=None):
         # 直線p1->p2と
         # 相手サイドの中心とボールを結ぶ直線が交差する点で、ボールを見る
         line = ConstraintLine()
@@ -286,10 +293,13 @@ class RobotOperator(Node):
         line.p3.append(self._xy_their_side_center())
         line.p4.append(self._xy_object_ball())
         line.theta = self._theta_look_ball()
+        if offset_to_p2:
+            line.offset_intersection_to_p2.append(offset_to_p2)
+
         target = self._xy_their_goal()
         return self._set_goal(robot_id, self._with_reflect_kick(self._line_goal(line, keep=True), target, kick_pass=False))
     
-    def move_to_cross_line_our_center_and_ball(self, robot_id, p1_x, p1_y, p2_x, p2_y):
+    def move_to_cross_line_our_center_and_ball(self, robot_id, p1_x, p1_y, p2_x, p2_y, offset_to_p2=None):
         # 直線p1->p2と
         # 自分サイドの中心とボールを結ぶ直線が交差する点で、ボールを見る
         line = ConstraintLine()
@@ -301,9 +311,12 @@ class RobotOperator(Node):
         line.p3.append(self._xy_our_side_center())
         line.p4.append(self._xy_object_ball())
         line.theta = self._theta_look_ball()
+        if offset_to_p2:
+            line.offset_intersection_to_p2.append(offset_to_p2)
+
         return self._set_goal(robot_id, self._with_receive(self._line_goal(line, keep=True)))
 
-    def move_to_cross_line_our_center_and_ball_with_reflect(self, robot_id, p1_x, p1_y, p2_x, p2_y):
+    def move_to_cross_line_our_center_and_ball_with_reflect(self, robot_id, p1_x, p1_y, p2_x, p2_y, offset_to_p2=None):
         # 直線p1->p2と
         # 自分サイドの中心とボールを結ぶ直線が交差する点で、ボールを見る
         line = ConstraintLine()
@@ -315,6 +328,9 @@ class RobotOperator(Node):
         line.p3.append(self._xy_our_side_center())
         line.p4.append(self._xy_object_ball())
         line.theta = self._theta_look_ball()
+        if offset_to_p2:
+            line.offset_intersection_to_p2.append(offset_to_p2)
+
         target = self._xy_their_goal()
         return self._set_goal(robot_id, self._with_reflect_kick(self._line_goal(line, keep=True), target, kick_pass=False))
 

--- a/consai_examples/consai_examples/robot_operator.py
+++ b/consai_examples/consai_examples/robot_operator.py
@@ -258,7 +258,7 @@ class RobotOperator(Node):
         line.p3.append(self._xy_our_goal())
         line.p4.append(self._xy_object_ball())
         line.theta = self._theta_look_ball()
-        if offset_to_p2:
+        if offset_to_p2 is not None:
             line.offset_intersection_to_p2.append(offset_to_p2)
 
         target = self._xy_their_goal()
@@ -276,7 +276,7 @@ class RobotOperator(Node):
         line.p3.append(self._xy_their_side_center())
         line.p4.append(self._xy_object_ball())
         line.theta = self._theta_look_ball()
-        if offset_to_p2:
+        if offset_to_p2 is not None:
             line.offset_intersection_to_p2.append(offset_to_p2)
 
         return self._set_goal(robot_id, self._with_receive(self._line_goal(line, keep=True)))
@@ -293,7 +293,7 @@ class RobotOperator(Node):
         line.p3.append(self._xy_their_side_center())
         line.p4.append(self._xy_object_ball())
         line.theta = self._theta_look_ball()
-        if offset_to_p2:
+        if offset_to_p2 is not None:
             line.offset_intersection_to_p2.append(offset_to_p2)
 
         target = self._xy_their_goal()
@@ -311,7 +311,7 @@ class RobotOperator(Node):
         line.p3.append(self._xy_our_side_center())
         line.p4.append(self._xy_object_ball())
         line.theta = self._theta_look_ball()
-        if offset_to_p2:
+        if offset_to_p2 is not None:
             line.offset_intersection_to_p2.append(offset_to_p2)
 
         return self._set_goal(robot_id, self._with_receive(self._line_goal(line, keep=True)))
@@ -328,7 +328,7 @@ class RobotOperator(Node):
         line.p3.append(self._xy_our_side_center())
         line.p4.append(self._xy_object_ball())
         line.theta = self._theta_look_ball()
-        if offset_to_p2:
+        if offset_to_p2 is not None:
             line.offset_intersection_to_p2.append(offset_to_p2)
 
         target = self._xy_their_goal()

--- a/consai_msgs/msg/ConstraintLine.msg
+++ b/consai_msgs/msg/ConstraintLine.msg
@@ -12,3 +12,7 @@ ConstraintTheta theta
 # Line1to2上で、Line3to4と交わるところを目標位置とする
 ConstraintXY[<=1] p3
 ConstraintXY[<=1] p4 
+# Line1to2上での交点からp2へのオフセット距離
+# 負の値を入れるとp1側へオフセットする
+# このオフセット距離によって目標位置がp1, p2をはみ
+float64[<=1] offset_intersection_to_p2

--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -331,13 +331,19 @@ bool FieldInfoParser::parse_constraint_line(
     // 交点が直線p1->p2をはみ出る場合は、p1 or p2に置き換える
     auto intersection_1to2 = trans_1to2.transform(intersection);
     auto p2_1to2 = trans_1to2.transform(p2);
+    auto parsed_pose_1to2 = intersection_1to2;
+
     if (intersection_1to2.x < 0.0) {
-      parsed_pose = p1;
+      parsed_pose_1to2.x = 0.0;
     } else if (intersection_1to2.x > p2_1to2.x) {
-      parsed_pose = p2;
-    } else {
-      parsed_pose = intersection;
+      parsed_pose_1to2.x = p2_1to2.x;
+    } 
+    // オフセットを加算する。オフセットによりp1, p2をはみ出ることが可能
+    if (line.offset_intersection_to_p2.size() > 0) {
+      parsed_pose_1to2.x += line.offset_intersection_to_p2[0];
     }
+    // 座標系をもとに戻す
+    parsed_pose = trans_1to2.inverted_transform(parsed_pose_1to2);
   }else {
     // 直線p1->p2上で、p1からdistanceだけ離れた位置を目標位置する
     parsed_pose = trans_1to2.inverted_transform(line.distance, 0, 0);


### PR DESCRIPTION
ConstraintLineに交点からのオフセットを設定するための`offset_intersection_to_p2`を追加します。

control.pyの`test_defend_goal_on_line`を実行すると動作を確認できます。