### PR TITLE
ボール500mm回避の処理を更新。フィールド外に目標位置を生成しない

### DIFF
--- a/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
@@ -122,6 +122,7 @@ private:
     const TrackedRobot & my_robot, const State & goal_pose,
     State & avoidance_pose) const;
   bool avoid_ball_500mm(
+    const State & final_goal_pose,
     const State & goal_pose, const TrackedBall & ball,
     State & avoidance_pose) const;
 

--- a/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
@@ -122,7 +122,7 @@ private:
     const TrackedRobot & my_robot, const State & goal_pose,
     State & avoidance_pose) const;
   bool avoid_ball_500mm(
-    const TrackedRobot & my_robot, const State & goal_pose, const TrackedBall & ball,
+    const State & goal_pose, const TrackedBall & ball,
     State & avoidance_pose) const;
 
   std::shared_ptr<TrackedFrame> detection_tracked_;


### PR DESCRIPTION
ボール周囲の回避を改善します。

- ボールの円周上を移動して回避する処理を削除します
  - デフォルトでobstacle_avoidance()でのボール回避が働くのではずしました
 - フィールド外に目標位置が出たとき、フィールド内に目標位置をずらす

![image](https://user-images.githubusercontent.com/18494952/236514058-a0119fe9-d16c-476d-8d20-2bc3992bc6fd.png)
