### PR TITLE
センターバック(ゴール前DF)を単一ファイル化＆並んで移動できるように修正

### DIFF
--- a/consai_examples/CMakeLists.txt
+++ b/consai_examples/CMakeLists.txt
@@ -31,6 +31,7 @@ install(PROGRAMS
     ${PROJECT_NAME}/decisions/attacker.py
     ${PROJECT_NAME}/decisions/center_back1.py
     ${PROJECT_NAME}/decisions/center_back2.py
+    ${PROJECT_NAME}/decisions/center_back.py
     ${PROJECT_NAME}/decisions/decision_base.py
     ${PROJECT_NAME}/decisions/goalie.py
     ${PROJECT_NAME}/decisions/side_back1.py

--- a/consai_examples/consai_examples/decisions/center_back.py
+++ b/consai_examples/consai_examples/decisions/center_back.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# coding: UTF-8
+
+# Copyright 2023 Roots
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+
+from decisions.decision_base import DecisionBase
+from field_observer import FieldObserver
+
+class CenterBackID(Enum):
+    # ゾーンディフェンスは最大4台まで
+    CENTER_BACK1 = 0
+    CENTER_BACK2 = 1
+
+class CenterBackDecision(DecisionBase):
+
+    def __init__(self, robot_operator, field_observer, center_back_id: CenterBackID):
+        super().__init__(robot_operator, field_observer)
+        self._center_back_id = center_back_id
+
+        self._our_penalty_pos_x = -self._PENALTY_WAIT_X
+        self._our_penalty_pos_y = 4.5 - 0.3 * (1.0 + self._center_back_id.value)
+        self._their_penalty_pos_x = self._PENALTY_WAIT_X
+        self._their_penalty_pos_y = 4.5 - 0.3 * (1.0 + self._center_back_id.value)
+        self._ball_placement_pos_x = -6.0 + 2.0
+        self._ball_placement_pos_y = 1.8 - 0.3 * (1.0 + self._center_back_id.value)
+
+    def _defend_upper_defense_area(self, robot_id, base_id):
+        # ディフェンスエリアの上半分を守る
+        ID_UPPER = base_id + 100
+        ID_FRONT = base_id + 200
+        ID_LOWER = base_id + 300
+
+        # ボールが左上にあれば上側をまもる
+        if self._ball_zone_state == FieldObserver.BALL_ZONE_LEFT_TOP:
+            if self._act_id != ID_UPPER:
+                self._defend_upper_top_defense_area(robot_id)
+                self._act_id = ID_UPPER
+        elif self._ball_zone_state == FieldObserver.BALL_ZONE_LEFT_BOTTOM:
+            if self._act_id != ID_LOWER:
+                self._defend_lower_bottom_defense_area(robot_id)
+                self._act_id = ID_LOWER
+        else:
+            if self._act_id != ID_FRONT:
+                self._defend_upper_front_defense_area(robot_id)
+                self._act_id = ID_FRONT
+
+    def _defend_upper_front_defense_area(self, robot_id):
+        # ディフェンスエリアの前側を守る
+        p1_x = -6.0 + 1.8 + 0.5
+        p1_y = 1.8
+        p2_x = -6.0 + 1.8 + 0.5
+        p2_y = -1.8
+        # self._operator.move_to_line_to_defend_our_goal(robot_id, p1_x, p1_y, p2_x, p2_y)
+        self._operator.move_to_line_to_defend_our_goal_with_reflect(robot_id, p1_x, p1_y, p2_x, p2_y)
+
+    def _defend_upper_front_defense_area_with_kick(self, robot_id):
+        # ディフェンスエリアの前側を守る(リフレクトキック狙い)
+        p1_x = -6.0 + 1.8 + 0.5
+        p1_y = 1.8
+        p2_x = -6.0 + 1.8 + 0.5
+        p2_y = -1.8
+        self._operator.move_to_line_to_defend_our_goal_with_reflect(robot_id, p1_x, p1_y, p2_x, p2_y)
+
+    def _defend_lower_bottom_defense_area(self, robot_id):
+        # ディフェンスエリアの下側(yマイナス側)を守る
+        p1_x = -6.0 + 0.3
+        p1_y = -1.8 - 0.5
+        p2_x = -6.0 + 1.8 + 0.3
+        p2_y = -1.8 - 0.5
+        self._operator.move_to_line_to_defend_our_goal_with_reflect(robot_id, p1_x, p1_y, p2_x, p2_y)
+
+    def _defend_upper_top_defense_area(self, robot_id):
+        # ディフェンスエリアの上側(yプラス側)を守る
+        p1_x = -6.0 + 0.3
+        p1_y = 1.8 + 0.5
+        p2_x = -6.0 + 1.8 + 0.3
+        p2_y = 1.8 + 0.5
+        # self._operator.move_to_line_to_defend_our_goal(robot_id, p1_x, p1_y, p2_x, p2_y)
+        self._operator.move_to_line_to_defend_our_goal_with_reflect(robot_id, p1_x, p1_y, p2_x, p2_y)
+
+    
+
+    def stop(self, robot_id):
+        if self._act_id != self.ACT_ID_STOP:
+            self._defend_upper_front_defense_area(robot_id)
+            self._act_id = self.ACT_ID_STOP
+
+    def inplay(self, robot_id):
+        self._defend_upper_defense_area(robot_id, self.ACT_ID_INPLAY)
+
+    def our_pre_kickoff(self, robot_id):
+        if self._act_id != self.ACT_ID_PRE_KICKOFF:
+            self._defend_upper_front_defense_area(robot_id)
+            self._act_id = self.ACT_ID_PRE_KICKOFF
+
+    def our_kickoff(self, robot_id):
+        if self._act_id != self.ACT_ID_KICKOFF:
+            self._defend_upper_front_defense_area(robot_id)
+            self._act_id = self.ACT_ID_KICKOFF
+
+    def their_pre_kickoff(self, robot_id):
+        if self._act_id != self.ACT_ID_PRE_KICKOFF:
+            self._defend_upper_front_defense_area(robot_id)
+            self._act_id = self.ACT_ID_PRE_KICKOFF
+
+    def their_kickoff(self, robot_id):
+        if self._act_id != self.ACT_ID_KICKOFF:
+            self._defend_upper_front_defense_area(robot_id)
+            self._act_id = self.ACT_ID_KICKOFF
+
+    def our_pre_penalty(self, robot_id):
+        if self._act_id != self.ACT_ID_PRE_PENALTY:
+            self._operator.move_to_look_ball(robot_id, self._our_penalty_pos_x, self._our_penalty_pos_y)
+            self._act_id = self.ACT_ID_PRE_PENALTY
+
+    def our_penalty(self, robot_id):
+        if self._act_id != self.ACT_ID_PENALTY:
+            self._operator.move_to_look_ball(robot_id, self._our_penalty_pos_x, self._our_penalty_pos_y)
+            self._act_id = self.ACT_ID_PENALTY
+
+    def their_pre_penalty(self, robot_id):
+        if self._act_id != self.ACT_ID_PRE_PENALTY:
+            self._operator.move_to_look_ball(robot_id, self._their_penalty_pos_x, self._their_penalty_pos_y)
+            self._act_id = self.ACT_ID_PRE_PENALTY
+
+    def their_penalty(self, robot_id):
+        if self._act_id != self.ACT_ID_PENALTY:
+            self._operator.move_to_look_ball(robot_id, self._their_penalty_pos_x, self._their_penalty_pos_y)
+            self._act_id = self.ACT_ID_PENALTY
+
+    def our_penalty_inplay(self, robot_id):
+        if self._act_id != self.ACT_ID_INPLAY:
+            self._operator.stop(robot_id)
+            self._act_id = self.ACT_ID_INPLAY
+
+    def their_penalty_inplay(self, robot_id):
+        if self._act_id != self.ACT_ID_INPLAY:
+            self._operator.stop(robot_id)
+            self._act_id = self.ACT_ID_INPLAY
+
+    def our_direct(self, robot_id):
+        if self._act_id != self.ACT_ID_DIRECT:
+            self._defend_upper_front_defense_area(robot_id)
+            self._act_id = self.ACT_ID_DIRECT
+
+    def their_direct(self, robot_id):
+        if self._act_id != self.ACT_ID_DIRECT:
+            self._defend_upper_front_defense_area(robot_id)
+            self._act_id = self.ACT_ID_DIRECT
+
+    def our_indirect(self, robot_id):
+        if self._act_id != self.ACT_ID_INDIRECT:
+            self._defend_upper_front_defense_area(robot_id)
+            self._act_id = self.ACT_ID_INDIRECT
+
+    def their_indirect(self, robot_id):
+        if self._act_id != self.ACT_ID_INDIRECT:
+            self._defend_upper_front_defense_area(robot_id)
+            self._act_id = self.ACT_ID_INDIRECT
+
+    def our_ball_placement(self, robot_id, placement_pos):
+        if self._act_id != self.ACT_ID_OUR_PLACEMENT:
+            self._operator.move_to_look_ball(robot_id, self._ball_placement_pos_x, self._ball_placement_pos_y)
+            self._act_id = self.ACT_ID_OUR_PLACEMENT
+
+    def their_ball_placement(self, robot_id, placement_pos):
+        if self._act_id != self.ACT_ID_THEIR_PLACEMENT:
+            self._operator.move_to_look_ball(robot_id, self._ball_placement_pos_x, self._ball_placement_pos_y)
+            self._act_id = self.ACT_ID_THEIR_PLACEMENT

--- a/consai_examples/consai_examples/decisions/decision_base.py
+++ b/consai_examples/consai_examples/decisions/decision_base.py
@@ -65,6 +65,9 @@ class DecisionBase(object):
     def set_ball_zone_state(self, ball_zone_state):
         self._ball_zone_state = ball_zone_state
 
+    def set_num_of_center_back_roles(self, num_of_center_back_roles):
+        self._num_of_center_back_roles = num_of_center_back_roles
+
     def set_num_of_zone_roles(self, num_of_zone_roles):
         self._num_of_zone_roles = num_of_zone_roles
 

--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -31,6 +31,7 @@ from decisions.side_wing import SideWingDecision, WingID
 from decisions.sub_attacker import SubAttackerDecision
 from decisions.substitute import SubstituteDecision
 from decisions.zone_defense import ZoneDefenseDecision, ZoneDefenseID
+from decisions.center_back import CenterBackDecision, CenterBackID
 from field_observer import FieldObserver
 from rclpy.executors import MultiThreadedExecutor
 from referee_parser import RefereeParser
@@ -219,8 +220,8 @@ if __name__ == '__main__':
     decisions = {
         RoleName.GOALIE: GoaleDecision(operator, observer),
         RoleName.ATTACKER: AttackerDecision(operator, observer),
-        RoleName.CENTER_BACK1: CenterBack1Decision(operator, observer),
-        RoleName.CENTER_BACK2: CenterBack2Decision(operator, observer),
+        RoleName.CENTER_BACK1: CenterBackDecision(operator, observer, CenterBackID.CENTER_BACK1),
+        RoleName.CENTER_BACK2: CenterBackDecision(operator, observer, CenterBackID.CENTER_BACK2),
         RoleName.SUB_ATTACKER: SubAttackerDecision(operator, observer),
         RoleName.ZONE1: ZoneDefenseDecision(operator, observer, ZoneDefenseID.ZONE1),
         RoleName.ZONE2: ZoneDefenseDecision(operator, observer, ZoneDefenseID.ZONE2),

--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -222,6 +222,9 @@ if __name__ == '__main__':
     decisions = {
         RoleName.GOALIE: GoaleDecision(operator, observer),
         RoleName.ATTACKER: AttackerDecision(operator, observer),
+        # FIXME: 大会終わったらコメント部分消す
+        # RoleName.CENTER_BACK1: CenterBack1Decision(operator, observer),
+        # RoleName.CENTER_BACK2: CenterBack2Decision(operator, observer),
         RoleName.CENTER_BACK1: CenterBackDecision(operator, observer, CenterBackID.CENTER_BACK1),
         RoleName.CENTER_BACK2: CenterBackDecision(operator, observer, CenterBackID.CENTER_BACK2),
         RoleName.SUB_ATTACKER: SubAttackerDecision(operator, observer),

--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -87,12 +87,12 @@ def main():
             enable_update_attacker_by_ball_pos(),
             referee.max_allowed_our_bots())
 
-        # 担当者がいるroleの中から、センターバックの数を抽出する
-        num_of_center_back_roles = num_of_active_center_back_roles(assigned_roles)
         # 担当者がいるroleの中から、ゾーンディフェンスの数を抽出する
         assigned_roles = [ t[0] for t in assignor.get_assigned_roles_and_ids() ]
         num_of_zone_roles = num_of_active_zone_roles(assigned_roles)
         zone_targets = observer.update_zone_targets(num_of_zone_roles)
+        # 担当者がいるroleの中から、センターバックの数を抽出する
+        num_of_center_back_roles = num_of_active_center_back_roles(assigned_roles)
         
         for role, robot_id in assignor.get_assigned_roles_and_ids():
             # 役割が変わったロボットのみ、行動を更新する

--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -47,6 +47,13 @@ def num_of_active_zone_roles(active_roles):
         RoleName.ZONE4]
     return len(set(role_zone_list) & set(active_roles))
 
+def num_of_active_center_back_roles(active_roles):
+    # アクティブなセンターバック担当者の数を返す
+    role_center_back_list = [
+        RoleName.CENTER_BACK1,
+        RoleName.CENTER_BACK2]
+    return len(set(role_center_back_list) & set(active_roles))
+
 def enable_update_attacker_by_ball_pos():
     # アタッカーの切り替わりを防ぐため、
     # ボールが動いてたり、ディフェンスエリアや自ゴール側場外にあるときは役割を更新しない
@@ -77,6 +84,8 @@ def main():
             enable_update_attacker_by_ball_pos(),
             referee.max_allowed_our_bots())
 
+        # 担当者がいるroleの中から、センターバックの数を抽出する
+        num_of_center_back_roles = num_of_active_center_back_roles(assigned_roles)
         # 担当者がいるroleの中から、ゾーンディフェンスの数を抽出する
         assigned_roles = [ t[0] for t in assignor.get_assigned_roles_and_ids() ]
         num_of_zone_roles = num_of_active_zone_roles(assigned_roles)
@@ -94,6 +103,8 @@ def main():
             decisions[role].set_ball_placement_state(ball_placement_state)
             # ボールゾーン状態をセットする
             decisions[role].set_ball_zone_state(ball_zone_state)
+            # センターバックの担当者数をセットする
+            decisions[role].set_num_of_center_back_roles(num_of_center_back_roles)
             # ゾーンディフェンスの担当者数をセットする
             decisions[role].set_num_of_zone_roles(num_of_zone_roles)
             # ゾーンディフェンスのターゲットをセットする


### PR DESCRIPTION
- センターバックのdecisionを1ファイルにした
- ゴール前DFが2台並んで移動するように

現在ボールが反対サイド（ゴールから見て右から左に移動、など）に移動したときに  
センターバックたちがDFエリアに侵入して移動する問題があるのでドラフトとします  