### PR TITLE
ロボットの向きをわかりやすくする

### DIFF
--- a/consai_vision_tracker/src/visualization_data_handler.cpp
+++ b/consai_vision_tracker/src/visualization_data_handler.cpp
@@ -224,7 +224,7 @@ TrackedFrame::UniquePtr VisualizationDataHandler::publish_vis_tracked(
 
   VisRobot vis_robot;
   vis_robot.line_color.name = "black";
-  vis_robot.line_size = 1;
+  vis_robot.line_size = 4;
   for (const auto & robot : msg->robots) {
     if (robot.visibility.size() <= 0 || robot.visibility[0] < 0.5) {
       continue;

--- a/consai_visualizer/src/consai_visualizer/field_widget.py
+++ b/consai_visualizer/src/consai_visualizer/field_widget.py
@@ -518,7 +518,7 @@ class FieldWidget(QWidget):
         size = shape.radius * 2 * self._scale_field_to_draw
         rect = QRectF(top_left, QSizeF(size, size))
 
-        FRONT_ANGLE = 55  # ロボットの前方を描画する角度
+        FRONT_ANGLE = 65  # ロボットの前方を描画する角度（わかりやすくするためルールより大きい）
         start_angle = int(math.degrees(shape.theta) - FRONT_ANGLE * 0.5) * 16
         span_angle = (-360 + FRONT_ANGLE) * 16
         painter.drawChord(rect, start_angle, span_angle)
@@ -526,7 +526,7 @@ class FieldWidget(QWidget):
         # ロボットID
         FONT_SIZE = int(shape.radius * 111)  # ロボットサイズに比例したフォントサイズ
         text_point = self._convert_field_to_draw_point(
-            shape.x - shape.radius * 0.8,
+            shape.x - shape.radius * 0.5,
             shape.y - shape.radius * 0.5)
         self._draw_text(painter, text_point, str(shape.id), FONT_SIZE)
 


### PR DESCRIPTION

#133 を解決します

- ロボットの外形線を太くしました
- ロボット前面の直線部分を長くしました

![image](https://github.com/SSL-Roots/consai_ros2/assets/18494952/8dc94104-24a5-46fa-a946-3dee1a0d5539)
