### PR TITLE
ボールボーイロボの制御を追加

### DIFF
--- a/consai_examples/CMakeLists.txt
+++ b/consai_examples/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(ament_cmake REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME})
 install(PROGRAMS
+    ${PROJECT_NAME}/ball_boy_test.py
     ${PROJECT_NAME}/control.py
     ${PROJECT_NAME}/control_by_referee.py
     ${PROJECT_NAME}/control_with_role.py

--- a/consai_examples/consai_examples/ball_boy_test.py
+++ b/consai_examples/consai_examples/ball_boy_test.py
@@ -23,18 +23,19 @@ from rclpy.executors import MultiThreadedExecutor
 from robot_operator import RobotOperator
 
 from operation import Operation
-from operation import OneShotOperation
 from operation import TargetXY
 from operation import TargetTheta
 
+
 def ball_boy_test(robot_id: int, target_x: float, target_y: float):
     move_to_ball = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
-    dribble_operation =move_to_ball.with_ball_boy_dribbling_to(TargetXY.value(target_x, target_y))
+    dribble_operation = move_to_ball.with_ball_boy_dribbling_to(TargetXY.value(target_x, target_y))
 
     operator_node.operate(robot_id, dribble_operation)
 
     while operator_node.robot_is_free(robot_id) is False:
         pass
+
 
 if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()

--- a/consai_examples/consai_examples/ball_boy_test.py
+++ b/consai_examples/consai_examples/ball_boy_test.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+# coding: UTF-8
+
+# Copyright 2023 Roots
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import threading
+
+import rclpy
+from rclpy.executors import MultiThreadedExecutor
+from robot_operator import RobotOperator
+
+from operation import Operation
+from operation import OneShotOperation
+from operation import TargetXY
+from operation import TargetTheta
+
+def ball_boy_test(robot_id: int, target_x: float, target_y: float):
+    move_to_ball = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
+    dribble_operation =move_to_ball.with_ball_boy_dribbling_to(TargetXY.value(target_x, target_y))
+
+    operator_node.operate(robot_id, dribble_operation)
+
+    while operator_node.robot_is_free(robot_id) is False:
+        pass
+
+if __name__ == '__main__':
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument('--yellow',
+                            default=False,
+                            action='store_true',
+                            help='yellowロボットを動かす場合にセットする')
+    arg_parser.add_argument('--invert',
+                            default=False,
+                            action='store_true',
+                            help='ball placementの目標座標を反転する場合にセットする')
+    arg_parser.add_argument('-robot_id', default=0)
+    arg_parser.add_argument('-x', default=0.0)
+    arg_parser.add_argument('-y', default=0.0)
+    args = arg_parser.parse_args()
+
+    rclpy.init(args=None)
+
+    operator_node = RobotOperator(target_is_yellow=args.yellow)
+
+    # すべてのロボットの衝突回避を解除
+    for i in range(16):
+        operator_node.disable_avoid_obstacles(i)
+
+    executor = MultiThreadedExecutor()
+    executor.add_node(operator_node)
+
+    # エグゼキュータは別スレッドでspinさせ続ける
+    executor_thread = threading.Thread(target=executor.spin, daemon=True)
+    executor_thread.start()
+
+    try:
+        ball_boy_test(int(args.robot_id), float(args.x), float(args.y))
+    except KeyboardInterrupt:
+        pass
+
+    executor.shutdown()
+    rclpy.shutdown()

--- a/consai_examples/consai_examples/ball_boy_test.py
+++ b/consai_examples/consai_examples/ball_boy_test.py
@@ -28,7 +28,8 @@ from operation import TargetTheta
 
 
 def ball_boy_test(robot_id: int, target_x: float, target_y: float):
-    move_to_ball = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
+    standby_position = TargetXY.value(0.0, -2.0)  # ボールボーイの待機位置
+    move_to_ball = Operation().move_to_pose(standby_position, TargetTheta.look_ball())
     dribble_operation = move_to_ball.with_ball_boy_dribbling_to(TargetXY.value(target_x, target_y))
 
     operator_node.operate(robot_id, dribble_operation)

--- a/consai_examples/consai_examples/operation.py
+++ b/consai_examples/consai_examples/operation.py
@@ -245,6 +245,12 @@ class Operation():
         goal.kick_target = target_xy.constraint
         return Operation(goal)
 
+    def with_ball_boy_dribbling_to(self, target_xy: TargetXY) -> 'Operation':
+        goal = deepcopy(self._goal)
+        goal.ball_boy_dribble_enable = True
+        goal.dribble_target = target_xy.constraint
+        return Operation(goal)
+
 
 class OneShotOperation(Operation):
     def __init__(self, goal: RobotControl.Goal = None) -> None:

--- a/consai_examples/tests/test_operation.py
+++ b/consai_examples/tests/test_operation.py
@@ -154,6 +154,15 @@ def test_with_reflecting_to():
     assert goal.kick_target.object[0].type == ConstraintObject.THEIR_GOAL
 
 
+def test_with_ball_boy_dribbling_to():
+    operation = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
+    operation = operation.with_ball_boy_dribbling_to(TargetXY.our_robot(3))
+    goal = operation.get_goal()
+    assert goal.ball_boy_dribble_enable is True
+    assert goal.dribble_target.object[0].type == ConstraintObject.OUR_ROBOT
+    assert goal.dribble_target.object[0].robot_id == 3
+
+
 def test_keep_control_operation():
     goal = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball()).get_goal()
     assert len(goal.pose) >= 1

--- a/consai_msgs/action/RobotControl.action
+++ b/consai_msgs/action/RobotControl.action
@@ -26,6 +26,7 @@ ConstraintXY kick_target
 
 # dribble_enable = trueで、dribble_targetに向かってボールを運ぶ
 bool dribble_enable false
+bool ball_boy_dribble_enable false
 ConstraintXY dribble_target
 
 # 転がっているボールを受け取るときはtrue

--- a/consai_robot_controller/CMakeLists.txt
+++ b/consai_robot_controller/CMakeLists.txt
@@ -29,6 +29,7 @@ include_directories(include)
 
 # Controller Component
 add_library(controller_component SHARED
+  src/ball_boy_tactics.cpp
   src/controller_component.cpp
   src/field_info_parser.cpp
   src/geometry_tools.cpp
@@ -105,6 +106,7 @@ if(BUILD_TESTING)
   ament_add_gtest(control_tools_test test/control_tools_test.cpp src/control_tools.cpp)
   ament_add_gtest(field_info_parser_test
     test/field_info_parser_test.cpp
+    src/ball_boy_tactics.cpp
     src/geometry_tools.cpp
     src/field_info_parser.cpp)
   ament_target_dependencies(field_info_parser_test

--- a/consai_robot_controller/include/consai_robot_controller/ball_boy_tactics.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/ball_boy_tactics.hpp
@@ -15,6 +15,7 @@
 #ifndef CONSAI_ROBOT_CONTROLLER__BALL_BOY_TACTICS_HPP_
 #define CONSAI_ROBOT_CONTROLLER__BALL_BOY_TACTICS_HPP_
 
+#include <chrono>
 #include <map>
 
 #include "consai_msgs/msg/state2_d.hpp"
@@ -24,6 +25,7 @@
 namespace tactics
 {
 
+using Time = std::chrono::system_clock::time_point;
 using State = consai_msgs::msg::State2D;
 using TrackedBall = robocup_ssl_msgs::msg::TrackedBall;
 using TrackedRobot = robocup_ssl_msgs::msg::TrackedRobot;
@@ -77,14 +79,17 @@ public:
 
 private:
   bool need_reset_state(const TrackedRobot & my_robot, const TrackedBall & ball) const;
-  bool is_same(const State & target, const State & current) const;
+  bool is_same(
+    const State & target, const State & current, const double threshold_distance = 0.05) const;
 
-  TacticState tactic_approach(DataSet & data_set) const;
+  TacticState tactic_approach(DataSet & data_set);
   TacticState tactic_catch(DataSet & data_set) const;
-  TacticState tactic_carry(DataSet & data_set) const;
+  TacticState tactic_carry(DataSet & data_set);
   TacticState tactic_release(DataSet & data_set) const;
+  TacticState tactic_finish(DataSet & data_set) const;
 
   std::map<unsigned int, TacticState> tactic_state_;
+  std::map<unsigned int, Time> tactic_time_;
   std::map<TacticState, std::function<TacticState(DataSet & data_set)>> tactic_functions_;
 };
 

--- a/consai_robot_controller/include/consai_robot_controller/ball_boy_tactics.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/ball_boy_tactics.hpp
@@ -1,0 +1,93 @@
+// Copyright 2023 Roots
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONSAI_ROBOT_CONTROLLER__BALL_BOY_TACTICS_HPP_
+#define CONSAI_ROBOT_CONTROLLER__BALL_BOY_TACTICS_HPP_
+
+#include <map>
+
+#include "consai_msgs/msg/state2_d.hpp"
+#include "robocup_ssl_msgs/msg/tracked_ball.hpp"
+#include "robocup_ssl_msgs/msg/tracked_robot.hpp"
+
+namespace tactics
+{
+
+using State = consai_msgs::msg::State2D;
+using TrackedBall = robocup_ssl_msgs::msg::TrackedBall;
+using TrackedRobot = robocup_ssl_msgs::msg::TrackedRobot;
+
+enum class TacticState
+{
+  INIT,
+  APPROACH,
+  CATCH,
+  CARRY,
+  RELEASE,
+  FINISH,
+};
+
+class DataSet
+{
+public:
+  DataSet(
+    const State & parsed_pose, const State & dribble_target,
+    const TrackedRobot & my_robot, const TrackedBall & ball)
+  : parsed_pose_(parsed_pose), dribble_target_(dribble_target), my_robot_(my_robot), ball_(ball)
+  {}
+
+  void set_parsed_pose(const State & parsed_pose) {parsed_pose_ = parsed_pose;}
+  void set_parsed_dribble_power(const double & parsed_dribble_power)
+  {
+    parsed_dribble_power_ = parsed_dribble_power;
+  }
+  State get_parsed_pose(void) {return parsed_pose_;}
+  double get_parsed_dribble_power(void) {return parsed_dribble_power_;}
+  State get_dribble_target(void) {return dribble_target_;}
+  TrackedRobot get_my_robot(void) {return my_robot_;}
+  TrackedBall get_ball(void) {return ball_;}
+
+private:
+  State parsed_pose_;
+  double parsed_dribble_power_;
+  State dribble_target_;
+  TrackedRobot my_robot_;
+  TrackedBall ball_;
+};
+
+class BallBoyTactics
+{
+public:
+  BallBoyTactics();
+  ~BallBoyTactics() = default;
+  bool update(
+    const State & dribble_target, const TrackedRobot & my_robot, const TrackedBall & ball,
+    State & parsed_pose, double & parsed_dribble_power);
+
+private:
+  bool need_reset_state(const TrackedRobot & my_robot, const TrackedBall & ball) const;
+  bool is_same(const State & target, const State & current) const;
+
+  TacticState tactic_approach(DataSet & data_set) const;
+  TacticState tactic_catch(DataSet & data_set) const;
+  TacticState tactic_carry(DataSet & data_set) const;
+  TacticState tactic_release(DataSet & data_set) const;
+
+  std::map<unsigned int, TacticState> tactic_state_;
+  std::map<TacticState, std::function<TacticState(DataSet & data_set)>> tactic_functions_;
+};
+
+}  // namespace tactics
+
+#endif  // CONSAI_ROBOT_CONTROLLER__BALL_BOY_TACTICS_HPP_

--- a/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
@@ -107,6 +107,9 @@ private:
   bool parse_dribble(
     const State & dribble_target, const TrackedRobot & my_robot, const TrackedBall & ball,
     State & parsed_pose, double & parsed_dribble_power) const;
+  bool parse_ball_boy_dribble(
+    const State & dribble_target, const TrackedRobot & my_robot, const TrackedBall & ball,
+    State & parsed_pose, double & parsed_dribble_power) const;
   bool control_ball(
     const State & target, const TrackedRobot & my_robot, const TrackedBall & ball,
     const double & dribble_distance, State & parsed_pose, bool & need_kick,

--- a/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
@@ -29,6 +29,7 @@
 #include "consai_msgs/msg/named_targets.hpp"
 #include "consai_msgs/msg/parsed_referee.hpp"
 #include "consai_msgs/msg/state2_d.hpp"
+#include "consai_robot_controller/ball_boy_tactics.hpp"
 #include "consai_robot_controller/obstacle_environment.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "robocup_ssl_msgs/msg/geometry_data.hpp"
@@ -74,7 +75,7 @@ public:
   bool parse_goal(
     const std::shared_ptr<const RobotControl::Goal> goal,
     const TrackedRobot & my_robot, State & parsed_pose, State & final_goal_pose,
-    double & kick_power, double & dribble_power) const;
+    double & kick_power, double & dribble_power);
   std::vector<unsigned int> active_robot_id_list(const bool team_is_yellow) const;
   State modify_goal_pose_to_avoid_obstacles(
     const std::shared_ptr<const RobotControl::Goal> goal,
@@ -146,6 +147,7 @@ private:
   bool invert_;
   bool team_is_yellow_;
   std::map<std::string, State> named_targets_;
+  tactics::BallBoyTactics ball_boy_tactics_;
 };
 
 }  // namespace consai_robot_controller

--- a/consai_robot_controller/src/ball_boy_tactics.cpp
+++ b/consai_robot_controller/src/ball_boy_tactics.cpp
@@ -23,8 +23,9 @@ namespace tools = geometry_tools;
 static constexpr double DRIBBLE_CATCH = 1.0;
 static constexpr double DRIBBLE_RELEASE = 0.0;
 static constexpr double ROBOT_RADIUS = 0.180 * 0.5;
-static constexpr double DISTANCE_TO_CATCHER = 0.175;  // ロボット中心からボールキャッチャーまでの距離
-static const State FIELD_CENTER;
+// ロボット中心からボールキャッチャーまでの距離
+static constexpr double DISTANCE_TO_CATCHER = 0.175;
+static const State FIELD_CENTER;  // (0.0, 0.0, 0.0)がセットされる
 
 BallBoyTactics::BallBoyTactics()
 {

--- a/consai_robot_controller/src/ball_boy_tactics.cpp
+++ b/consai_robot_controller/src/ball_boy_tactics.cpp
@@ -23,7 +23,7 @@ namespace tools = geometry_tools;
 static constexpr double DRIBBLE_CATCH = 1.0;
 static constexpr double DRIBBLE_RELEASE = 0.0;
 static constexpr double ROBOT_RADIUS = 0.180 * 0.5;
-static constexpr double DISTANCE_TO_CATCHER = 0.17;  // ロボット中心からボールキャッチャーまでの距離
+static constexpr double DISTANCE_TO_CATCHER = 0.175;  // ロボット中心からボールキャッチャーまでの距離
 static const State FIELD_CENTER;
 
 BallBoyTactics::BallBoyTactics()
@@ -118,7 +118,7 @@ TacticState BallBoyTactics::tactic_approach(DataSet & data_set)
 TacticState BallBoyTactics::tactic_catch(DataSet & data_set) const
 {
   // キャッチャーを駆動させながら前進する
-  constexpr double DISTANCE_TO_CATCH = DISTANCE_TO_CATCHER * 0.85;
+  constexpr double DISTANCE_TO_CATCH = DISTANCE_TO_CATCHER * 0.95;
   constexpr double CATCH_TIME = 0.5;
 
   const auto robot_pose = tools::pose_state(data_set.get_my_robot());

--- a/consai_robot_controller/src/ball_boy_tactics.cpp
+++ b/consai_robot_controller/src/ball_boy_tactics.cpp
@@ -1,0 +1,177 @@
+// Copyright 2023 Roots
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "consai_robot_controller/ball_boy_tactics.hpp"
+#include "consai_robot_controller/geometry_tools.hpp"
+
+namespace tactics
+{
+
+namespace tools = geometry_tools;
+
+static constexpr double DRIBBLE_CATCH = 1.0;
+static constexpr double DRIBBLE_RELEASE = 0.0;
+static constexpr double ROBOT_RADIUS = 0.180 * 0.5;
+static constexpr double DISTANCE_TO_CATCHER = 0.18;  // ロボット中心からボールキャッチャーまでの距離
+static const State FIELD_CENTER;
+
+BallBoyTactics::BallBoyTactics()
+{
+  tactic_functions_[TacticState::APPROACH] = [this](DataSet & data_set) {
+      return tactic_approach(data_set);
+    };
+  tactic_functions_[TacticState::CATCH] = [this](DataSet & data_set) {
+      return tactic_catch(data_set);
+    };
+  tactic_functions_[TacticState::CARRY] = [this](DataSet & data_set) {
+      return tactic_carry(data_set);
+    };
+  tactic_functions_[TacticState::RELEASE] = [this](DataSet & data_set) {
+      return tactic_release(data_set);
+    };
+}
+
+bool BallBoyTactics::update(
+  const State & dribble_target, const TrackedRobot & my_robot, const TrackedBall & ball,
+  State & parsed_pose, double & parsed_dribble_power)
+{
+  const auto robot_id = my_robot.robot_id.id;
+  if (tactic_state_.find(robot_id) == tactic_state_.end()) {
+    tactic_state_[robot_id] = TacticState::APPROACH;
+  }
+
+  if (need_reset_state(my_robot, ball)) {
+    tactic_state_[robot_id] = TacticState::APPROACH;
+  }
+
+  DataSet data_set(parsed_pose, dribble_target, my_robot, ball);
+  tactic_state_[robot_id] = tactic_functions_[tactic_state_[robot_id]](data_set);
+
+  parsed_pose = data_set.get_parsed_pose();
+  parsed_dribble_power = data_set.get_parsed_dribble_power();
+
+  return true;
+}
+
+bool BallBoyTactics::need_reset_state(const TrackedRobot & my_robot, const TrackedBall & ball) const
+{
+  // 状態リセットが必要化判定する
+  const double RESET_DISTANCE = 0.5;
+
+  // ボールがロボットから離れたらリセットする
+  if (tools::distance(tools::pose_state(my_robot), tools::pose_state(ball)) > RESET_DISTANCE) {
+    return true;
+  }
+
+  return false;
+}
+
+bool BallBoyTactics::is_same(const State & target, const State & current) const
+{
+  constexpr double THRESHOLD_DISTANCE = ROBOT_RADIUS * 0.5;
+  const double THRESHOLD_ANGLE = tools::to_radians(10.0);
+
+  if (tools::distance(target, current) < THRESHOLD_DISTANCE &&
+    std::fabs(tools::normalize_theta(target.theta - current.theta)) < THRESHOLD_ANGLE)
+  {
+    return true;
+  }
+
+  return false;
+}
+
+TacticState BallBoyTactics::tactic_approach(DataSet & data_set) const
+{
+  // フィールド中心を背中にして、ボールに近づく
+  const auto robot_pose = tools::pose_state(data_set.get_my_robot());
+  const auto ball_pose = tools::pose_state(data_set.get_ball());
+
+  const auto angle_ball_to_center = tools::calc_angle(ball_pose, FIELD_CENTER);
+  const tools::Trans trans_BtoC(ball_pose, angle_ball_to_center);
+  const auto new_parsed_pose = trans_BtoC.inverted_transform(DISTANCE_TO_CATCHER, 0.0, -M_PI);
+  data_set.set_parsed_pose(new_parsed_pose);
+  data_set.set_parsed_dribble_power(DRIBBLE_RELEASE);
+
+  if (is_same(new_parsed_pose, robot_pose)) {
+    return TacticState::CATCH;
+  }
+
+  return TacticState::APPROACH;
+}
+
+TacticState BallBoyTactics::tactic_catch(DataSet & data_set) const
+{
+  // キャッチャーを駆動させながら前進する
+  constexpr double DISTANCE_TO_CATCH = DISTANCE_TO_CATCHER * 0.9;
+  const auto robot_pose = tools::pose_state(data_set.get_my_robot());
+  const auto ball_pose = tools::pose_state(data_set.get_ball());
+
+  const auto angle_ball_to_center = tools::calc_angle(ball_pose, FIELD_CENTER);
+  const tools::Trans trans_BtoC(ball_pose, angle_ball_to_center);
+  const auto new_parsed_pose = trans_BtoC.inverted_transform(DISTANCE_TO_CATCH, 0.0, -M_PI);
+  data_set.set_parsed_pose(new_parsed_pose);
+  data_set.set_parsed_dribble_power(DRIBBLE_CATCH);
+
+  if (is_same(new_parsed_pose, robot_pose)) {
+    return TacticState::CARRY;
+  }
+
+  return TacticState::CATCH;
+}
+
+TacticState BallBoyTactics::tactic_carry(DataSet & data_set) const
+{
+  // 目標位置へボールを運ぶ
+  const auto robot_pose = tools::pose_state(data_set.get_my_robot());
+  const auto ball_pose = tools::pose_state(data_set.get_ball());
+  const auto dribble_target = data_set.get_dribble_target();
+
+  const auto angle_target_to_robot = tools::calc_angle(dribble_target, robot_pose);
+  const tools::Trans trans_TtoR(dribble_target, angle_target_to_robot);
+  const auto new_parsed_pose = trans_TtoR.inverted_transform(DISTANCE_TO_CATCHER, 0.0, -M_PI);
+
+  data_set.set_parsed_pose(new_parsed_pose);
+  data_set.set_parsed_dribble_power(DRIBBLE_CATCH);
+
+  if (is_same(new_parsed_pose, robot_pose)) {
+    return TacticState::RELEASE;
+  }
+
+  return TacticState::CARRY;
+}
+
+TacticState BallBoyTactics::tactic_release(DataSet & data_set) const
+{
+  // ボールを離す
+  const double DISTANCE_TO_RELEASE = DISTANCE_TO_CATCHER + 0.0;
+  const auto robot_pose = tools::pose_state(data_set.get_my_robot());
+  const auto ball_pose = tools::pose_state(data_set.get_ball());
+  const auto dribble_target = data_set.get_dribble_target();
+
+  const auto angle_target_to_robot = tools::calc_angle(dribble_target, robot_pose);
+  const tools::Trans trans_TtoR(dribble_target, angle_target_to_robot);
+  const auto new_parsed_pose = trans_TtoR.inverted_transform(DISTANCE_TO_RELEASE, 0.0, -M_PI);
+
+  data_set.set_parsed_pose(new_parsed_pose);
+  data_set.set_parsed_dribble_power(DRIBBLE_RELEASE);
+
+  if (is_same(new_parsed_pose, robot_pose)) {
+    return TacticState::RELEASE;
+  }
+
+  return TacticState::RELEASE;
+}
+
+
+}  // namespace tactics

--- a/consai_robot_controller/src/ball_boy_tactics.cpp
+++ b/consai_robot_controller/src/ball_boy_tactics.cpp
@@ -49,6 +49,11 @@ bool BallBoyTactics::update(
   const State & dribble_target, const TrackedRobot & my_robot, const TrackedBall & ball,
   State & parsed_pose, double & parsed_dribble_power)
 {
+  // 外部から実行される関数
+  // ロボット（ロボットID）が持つ現在の戦術（Tactic）状態に合わせた関数を実行する
+  // 戦術状態は、各関数内で更新される
+  // 演算結果の移動目標位置・姿勢はparsed_poseに、ドリブルパワーはparsed_dribble_powerに格納される
+
   const auto robot_id = my_robot.robot_id.id;
   if (tactic_state_.find(robot_id) == tactic_state_.end()) {
     tactic_state_[robot_id] = TacticState::APPROACH;
@@ -69,7 +74,7 @@ bool BallBoyTactics::update(
 
 bool BallBoyTactics::need_reset_state(const TrackedRobot & my_robot, const TrackedBall & ball) const
 {
-  // 状態リセットが必要化判定する
+  // 状態リセットが必要か判定する
   const double RESET_DISTANCE = 0.5;
 
   // ボールがロボットから離れたらリセットする
@@ -118,6 +123,7 @@ TacticState BallBoyTactics::tactic_approach(DataSet & data_set)
 TacticState BallBoyTactics::tactic_catch(DataSet & data_set) const
 {
   // キャッチャーを駆動させながら前進する
+  // 掴む動作を完了させるため、一定時間待機する
   constexpr double DISTANCE_TO_CATCH = DISTANCE_TO_CATCHER * 0.95;
   constexpr double CATCH_TIME = 0.5;
 
@@ -166,7 +172,8 @@ TacticState BallBoyTactics::tactic_carry(DataSet & data_set)
 
 TacticState BallBoyTactics::tactic_release(DataSet & data_set) const
 {
-  // n秒経過するまでボールを離す
+  // ボールを離す
+  // 離す動作を完了させるため、一定時間待機する
   constexpr double RELEASE_TIME = 1.0;  // [s]
   const auto robot_pose = tools::pose_state(data_set.get_my_robot());
 

--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -224,6 +224,10 @@ bool FieldInfoParser::parse_goal(
       parse_constraint_xy(goal->dribble_target, target.x, target.y))
     {
       parse_dribble(target, my_robot, ball, parsed_pose, dribble_power);
+    } else if (goal->ball_boy_dribble_enable &&  // NOLINT
+      parse_constraint_xy(goal->dribble_target, target.x, target.y))
+    {
+      parse_ball_boy_dribble(target, my_robot, ball, parsed_pose, dribble_power);
     }
   }
 
@@ -648,6 +652,80 @@ bool FieldInfoParser::parse_dribble(
   } else {
     parsed_dribble_power = 0.0;
   }
+  return true;
+}
+
+bool FieldInfoParser::parse_ball_boy_dribble(
+    const State & dribble_target, const TrackedRobot & my_robot, const TrackedBall & ball,
+    State & parsed_pose, double & parsed_dribble_power) const
+{
+  // ボールボーイロボ用のドリブル関数
+  const double BALL_ARRIVAL_DISTANCE = 0.1;
+  const double RELEASE_DISTANCE = 0.5;
+  const double CATCH_DISTANCE = 0.2;
+
+  const double DRIBBLE_CATCH_POWER = 1.0;
+  const double DRIBBLE_RELEASE_POWER = 0.0;
+  const double ROBOT_RADIUS = 0.180 * 0.5;
+  const auto center_pose = State();
+  const auto ball_pose = tools::pose_state(ball);
+  const auto robot_pose = tools::pose_state(my_robot);
+
+  // ボールが目標位置に到着したら、ボールから離れた位置に移動する
+  if (tools::distance(ball_pose, dribble_target) < BALL_ARRIVAL_DISTANCE) {
+    const auto angle_target_to_robot = tools::calc_angle(dribble_target, robot_pose);
+    tools::Trans trans_TtoR(dribble_target, angle_target_to_robot);
+    parsed_pose = trans_TtoR.inverted_transform(RELEASE_DISTANCE, 0.0, -M_PI);
+    parsed_dribble_power = DRIBBLE_RELEASE_POWER;
+    return true;
+  }
+
+  // ロボットがボールを見ていたら、目標位置に向かって進む
+  const auto angle_robot_to_ball = tools::calc_angle(robot_pose, ball_pose);
+  const tools::Trans trans_RtoB(robot_pose, angle_robot_to_ball);
+  const auto  robot_pose_RtoB = trans_RtoB.transform(robot_pose);
+
+  // 早めにキャッチャーを動かす
+  std::cout << "theta:" << tools::to_degrees(std::fabs(robot_pose_RtoB.theta)) << std::endl;
+  std::cout << "distance:" << tools::distance(robot_pose, ball_pose) << std::endl;
+
+  const auto distance_RtoB = tools::distance(robot_pose, ball_pose);
+
+  // if (std::fabs(robot_pose_RtoB.theta) < tools::to_radians(10) &&
+  //     distance_RtoB > ROBOT_RADIUS && distance_RtoB < CATCH_DISTANCE) {
+  //   std::cout << "PRE CATCH!!!" << std::endl;
+  //   parsed_dribble_power = DRIBBLE_CATCH_POWER;
+  // } else {
+  //   parsed_dribble_power = DRIBBLE_RELEASE_POWER;
+  // }
+
+  if (std::fabs(robot_pose_RtoB.theta) < tools::to_radians(10) &&
+      distance_RtoB > ROBOT_RADIUS && distance_RtoB < CATCH_DISTANCE * 1.0) {
+    parsed_dribble_power = DRIBBLE_CATCH_POWER;
+
+    const auto angle_target_to_robot = tools::calc_angle(dribble_target, robot_pose);
+    tools::Trans trans_TtoR(dribble_target, angle_target_to_robot);
+    parsed_pose = trans_TtoR.inverted_transform(CATCH_DISTANCE, 0.0, -M_PI);
+    return true;
+  } else {
+    parsed_dribble_power = DRIBBLE_RELEASE_POWER;
+  }
+
+  // if (std::fabs(robot_pose_RtoB.theta) < tools::to_radians(10) &&
+  //     distance_RtoB > ROBOT_RADIUS && distance_RtoB < CATCH_DISTANCE * 1.2) {
+  //   std::cout << "CATCH!!!" << std::endl;
+  //   const auto angle_target_to_robot = tools::calc_angle(dribble_target, robot_pose);
+  //   tools::Trans trans_TtoR(dribble_target, angle_target_to_robot);
+  //   parsed_pose = trans_TtoR.inverted_transform(CATCH_DISTANCE, 0.0, -M_PI);
+  //   parsed_dribble_power = DRIBBLE_CATCH_POWER;
+  //   return true;
+  // }
+
+  // ロボットがボールをキャッチできそうな場合
+  const auto angle_ball_to_center = tools::calc_angle(ball_pose, center_pose);
+  tools::Trans trans_BtoC(ball_pose, angle_ball_to_center);
+  parsed_pose = trans_BtoC.inverted_transform(CATCH_DISTANCE * 0.8, 0.0, -M_PI);
+
   return true;
 }
 


### PR DESCRIPTION
ボールボーイロボの制御関数を追加します。

`RobotControl`アクションの`ball_boy_dribble_enable`をtrueにすると、
ボールボーイロボのボール運び動作を実行します。

下記の内容が未実装です。

- ボールへ近づくときのボール回避
- 長方形フィールドへの対応（角のボールが取れない）

## consai_examples

- ボールボーイロボのテスト関数を追加します

## consai_robot_controller

- BallBoyTacticsクラスを追加します
