### PR TITLE
STOP中のボール500 mm回避で、目標角度が反転する問題を修正

### DIFF
--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -1208,7 +1208,7 @@ bool FieldInfoParser::avoid_ball_500mm(
     // このとき、最終目標位置側に回避位置を置く
     avoidance_pose = trans_BtoG.inverted_transform(
       std::copysign(DISTANCE_TO_AVOID, final_goal_pose_BtoG.x), 0.0, 0.0);
-    avoidance_pose.theta = goal_pose.theta;
+    avoidance_pose.theta = final_goal_pose.theta;
 
     if (!geometry_) {
       return true;
@@ -1236,7 +1236,7 @@ bool FieldInfoParser::avoid_ball_500mm(
         DISTANCE_TO_AVOID * std::cos(add_angle),
         DISTANCE_TO_AVOID * std::sin(add_angle), 0.0);
     }
-    avoidance_pose.theta = goal_pose.theta;
+    avoidance_pose.theta = final_goal_pose.theta;
   }
   return true;
 }


### PR DESCRIPTION
キックオフ時にロボットが反転しないことを確認しました。

Close #129 