### PR TITLE
Use ssl-roots/grsim for scenario test

### DIFF
--- a/.docker/consai-grsim-compose.yml
+++ b/.docker/consai-grsim-compose.yml
@@ -1,10 +1,11 @@
 version: '3.8'
 services:
   grsim:
-    image: robocupssl/grsim
+    image: ghcr.io/ssl-roots/docker_images/grsim:main
     container_name: grsim
     network_mode: host
-    command: []
+    command: |
+      ./grSim --headless -platform offscreen
     tty: true
     stdin_open: true
     restart: "no"

--- a/.github/workflows/scenario_test.yaml
+++ b/.github/workflows/scenario_test.yaml
@@ -55,7 +55,7 @@ jobs:
     - name: Wait for game.py to start
       timeout-minutes: 5
       run: |
-        CHECK_INTERVAL=10
+        CHECK_INTERVAL=5
 
         until docker top consai 2>/dev/null | grep -q game.py
         do


### PR DESCRIPTION
ロボットを同時に複数turn offするとgrSimがクラッシュする問題があります。

https://github.com/RoboCup-SSL/grSim/issues/185

それを回避するため、SSL-RootsでフォークしたgrSimをシナリオテストCIに使用します。