### PR TITLE
Update avoid_ball_500mm

### DIFF
--- a/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
@@ -136,6 +136,7 @@ private:
     const TrackedRobot & my_robot, const State & goal_pose,
     State & avoidance_pose) const;
   bool avoid_ball_500mm(
+    const TrackedRobot & my_robot,
     const State & final_goal_pose,
     const State & goal_pose, const TrackedBall & ball,
     State & avoidance_pose) const;

--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -1199,78 +1199,78 @@ bool FieldInfoParser::avoid_ball_500mm(
   const auto ball_pose = tools::pose_state(ball);
 
   auto avoidance_on_line_robot_to_goal = [&]() {
-    // 自分と目標位置を結ぶ座標系を生成
-    const auto trans_RtoG = tools::Trans(robot_pose, tools::calc_angle(robot_pose, goal_pose));
-    const auto ball_pose_RtoG = trans_RtoG.transform(ball_pose);
-    const auto goal_pose_RtoG = trans_RtoG.transform(goal_pose);
+      // 自分と目標位置を結ぶ座標系を生成
+      const auto trans_RtoG = tools::Trans(robot_pose, tools::calc_angle(robot_pose, goal_pose));
+      const auto ball_pose_RtoG = trans_RtoG.transform(ball_pose);
+      const auto goal_pose_RtoG = trans_RtoG.transform(goal_pose);
 
-    // 自分と目標位置間にボールがなければ終了
-    if (ball_pose_RtoG.x < 0.0 || ball_pose_RtoG.x > goal_pose_RtoG.x) {
+      // 自分と目標位置間にボールがなければ終了
+      if (ball_pose_RtoG.x < 0.0 || ball_pose_RtoG.x > goal_pose_RtoG.x) {
+        return true;
+      }
+
+      // ボールが離れていれば終了
+      if (std::fabs(ball_pose_RtoG.y) > DISTANCE_TO_AVOID_THRESHOLD) {
+        return true;
+      }
+
+      // 回避位置を生成
+      const auto avoid_x = ball_pose_RtoG.x;
+      const auto avoid_y = ball_pose_RtoG.y - std::copysign(DISTANCE_TO_AVOID, ball_pose_RtoG.y);
+      avoidance_pose = trans_RtoG.inverted_transform(avoid_x, avoid_y, 0.0);
       return true;
-    }
-
-    // ボールが離れていれば終了
-    if (std::fabs(ball_pose_RtoG.y) > DISTANCE_TO_AVOID_THRESHOLD) {
-      return true;
-    }
-
-    // 回避位置を生成
-    const auto avoid_x = ball_pose_RtoG.x;
-    const auto avoid_y = ball_pose_RtoG.y - std::copysign(DISTANCE_TO_AVOID, ball_pose_RtoG.y);
-    avoidance_pose = trans_RtoG.inverted_transform(avoid_x, avoid_y, 0.0);
-    return true;
-  };
+    };
 
   auto make_a_gap_from_ball = [&]() {
-    const auto distance_BtoA = tools::distance(ball_pose, avoidance_pose);
-    // 目標位置がボールから離れていれば終了
-    if (distance_BtoA > DISTANCE_TO_AVOID_THRESHOLD) {
+      const auto distance_BtoA = tools::distance(ball_pose, avoidance_pose);
+      // 目標位置がボールから離れていれば終了
+      if (distance_BtoA > DISTANCE_TO_AVOID_THRESHOLD) {
+        return true;
+      }
+
+      // 目標位置とボールを結ぶ直線上で、目標位置をボールから離す
+      // このとき、最終目標位置側に回避位置を置く
+      const auto trans_BtoA = tools::Trans(
+        ball_pose, tools::calc_angle(ball_pose, avoidance_pose));
+      const auto final_goal_pose_BtoA = trans_BtoA.transform(final_goal_pose);
+
+      avoidance_pose = trans_BtoA.inverted_transform(
+        std::copysign(DISTANCE_TO_AVOID, final_goal_pose_BtoA.x), 0.0, 0.0);
       return true;
-    }
-
-    // 目標位置とボールを結ぶ直線上で、目標位置をボールから離す
-    // このとき、最終目標位置側に回避位置を置く
-    const auto trans_BtoA = tools::Trans(
-      ball_pose, tools::calc_angle(ball_pose, avoidance_pose));
-    const auto final_goal_pose_BtoA = trans_BtoA.transform(final_goal_pose);
-
-    avoidance_pose = trans_BtoA.inverted_transform(
-      std::copysign(DISTANCE_TO_AVOID, final_goal_pose_BtoA.x), 0.0, 0.0);
-    return true;
-  };
+    };
 
   auto avoid_outside_of_field = [&]() {
-    if (!geometry_) {
+      if (!geometry_) {
+        return true;
+      }
+
+      // フィールド外に目標位置が置かれた場合の処理
+      const auto BOUNDARY_WIDTH = geometry_->field.boundary_width * 0.001;
+      const auto FIELD_HALF_X = geometry_->field.field_length * 0.5 * 0.001;
+      const auto FIELD_HALF_Y = geometry_->field.field_width * 0.5 * 0.001;
+      // どれだけフィールドからはみ出たかを、0.0 ~ 1.0に変換する
+      // はみ出た分だけ目標位置をボール周囲でずらす
+      const auto trans_BtoA = tools::Trans(
+        ball_pose, tools::calc_angle(ball_pose, avoidance_pose));
+      const auto gain_x =
+        std::clamp((std::fabs(avoidance_pose.x) - FIELD_HALF_X) / BOUNDARY_WIDTH, 0.0, 1.0);
+      const auto gain_y =
+        std::clamp((std::fabs(avoidance_pose.y) - FIELD_HALF_Y) / BOUNDARY_WIDTH, 0.0, 1.0);
+
+      if (gain_x > 0.0) {
+        auto add_angle = std::copysign(gain_x * M_PI * 0.5, avoidance_pose.y);
+        avoidance_pose = trans_BtoA.inverted_transform(
+          DISTANCE_TO_AVOID * std::cos(add_angle),
+          DISTANCE_TO_AVOID * std::sin(add_angle), 0.0);
+      }
+      if (gain_y > 0.0) {
+        auto add_angle = std::copysign(gain_y * M_PI * 0.5, avoidance_pose.x);
+        avoidance_pose = trans_BtoA.inverted_transform(
+          DISTANCE_TO_AVOID * std::cos(add_angle),
+          DISTANCE_TO_AVOID * std::sin(add_angle), 0.0);
+      }
       return true;
-    }
-
-    // フィールド外に目標位置が置かれた場合の処理
-    const auto BOUNDARY_WIDTH = geometry_->field.boundary_width * 0.001;
-    const auto FIELD_HALF_X = geometry_->field.field_length * 0.5 * 0.001;
-    const auto FIELD_HALF_Y = geometry_->field.field_width * 0.5 * 0.001;
-    // どれだけフィールドからはみ出たかを、0.0 ~ 1.0に変換する
-    // はみ出た分だけ目標位置をボール周囲でずらす
-    const auto trans_BtoA = tools::Trans(
-      ball_pose, tools::calc_angle(ball_pose, avoidance_pose));
-    const auto gain_x =
-      std::clamp((std::fabs(avoidance_pose.x) - FIELD_HALF_X) / BOUNDARY_WIDTH, 0.0, 1.0);
-    const auto gain_y =
-      std::clamp((std::fabs(avoidance_pose.y) - FIELD_HALF_Y) / BOUNDARY_WIDTH, 0.0, 1.0);
-
-    if (gain_x > 0.0) {
-      auto add_angle = std::copysign(gain_x * M_PI * 0.5, avoidance_pose.y);
-      avoidance_pose = trans_BtoA.inverted_transform(
-        DISTANCE_TO_AVOID * std::cos(add_angle),
-        DISTANCE_TO_AVOID * std::sin(add_angle), 0.0);
-    }
-    if (gain_y > 0.0) {
-      auto add_angle = std::copysign(gain_y * M_PI * 0.5, avoidance_pose.x);
-      avoidance_pose = trans_BtoA.inverted_transform(
-        DISTANCE_TO_AVOID * std::cos(add_angle),
-        DISTANCE_TO_AVOID * std::sin(add_angle), 0.0);
-    }
-    return true;
-  };
+    };
 
   // 障害物がなければ、目標位置を回避位置とする
   avoidance_pose = goal_pose;

--- a/tests/test_scenario_stop.py
+++ b/tests/test_scenario_stop.py
@@ -16,6 +16,9 @@ import math
 import time
 
 from rcst.communication import Communication
+from rcst import calc
+from rcst.ball import Ball
+from rcst.robot import RobotDict
 
 
 def test_robot_speed(rcst_comm: Communication):
@@ -35,3 +38,41 @@ def test_robot_speed(rcst_comm: Communication):
             break
         time.sleep(1)
     assert success is True
+
+
+def blue_robot_did_not_avoid_ball(
+        ball: Ball, blue_robots: RobotDict, yellow_robots: RobotDict) -> bool:
+    for robot in blue_robots.values():
+        if calc.distance_robot_and_ball(robot, ball) < 0.4:
+            return True
+
+    return False
+
+
+def test_avoid_ball(rcst_comm: Communication):
+    rcst_comm.send_empty_world()
+    for i in range(11):
+        rcst_comm.send_blue_robot(i, -1.0, 3.0 - i * 0.5, math.radians(0))
+    time.sleep(3)  # Wait for the robots to be placed.
+
+    rcst_comm.observer.customized().register_sticky_true_callback(
+        "blue_robot_did_not_avoid_ball", blue_robot_did_not_avoid_ball)
+
+    rcst_comm.change_referee_command('STOP', 1.0)
+
+    def check(x: float, y: float, vx: float = 0.0, vy: float = 0.0):
+        rcst_comm.send_ball(x, y, vx, vy)
+        time.sleep(2)
+        rcst_comm.observer.reset()
+
+        success = True
+        for _ in range(5):
+            if rcst_comm.observer.customized().get_result("blue_robot_did_not_avoid_ball"):
+                success = False
+                break
+            time.sleep(1)
+        assert success is True
+
+    check(0, 0)
+    check(-3.5, 0)
+    check(-3.5, 0, vx=2.0)


### PR DESCRIPTION

ボール周りの回避を下記の3構成に変更します

- ロボットと目標位置を結ぶ直線上での回避
- ボール中心から直線的に目標位置を離す
- フィールド外に生成された目標位置をフィールド内に戻す

また、STOP中のボール回避用のシナリオテストを追加します。