### PR TITLE
Action通信をやめて、Topic通信でcontrollerに指令を送る

### DIFF
--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -80,7 +80,7 @@ def update_decisions(changed_ids: list[int], ball_state: int, ball_placement_sta
         # ゾーンディフェンスのターゲットをセットする
         decisions[role].set_zone_targets(zone_targets)
         # 障害物を回避する
-        decisions[role].enable_avoid_obstacles(robot_id)
+        # decisions[role].enable_avoid_obstacles(robot_id)
 
         # レフェリーコマンドに合わせて行動を決定する
         if referee.halt():

--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -79,8 +79,6 @@ def update_decisions(changed_ids: list[int], ball_state: int, ball_placement_sta
         decisions[role].set_num_of_zone_roles(num_of_zone_roles)
         # ゾーンディフェンスのターゲットをセットする
         decisions[role].set_zone_targets(zone_targets)
-        # 障害物を回避する
-        # decisions[role].enable_avoid_obstacles(robot_id)
 
         # レフェリーコマンドに合わせて行動を決定する
         if referee.halt():

--- a/consai_examples/consai_examples/operation.py
+++ b/consai_examples/consai_examples/operation.py
@@ -177,6 +177,11 @@ class Operation():
         goal.avoid_pushing_robots = True
         return Operation(goal)
 
+    def restrict_velocity_xy(self, velocity: float) -> 'Operation':
+        goal = deepcopy(self._goal)
+        goal.max_velocity_xy.insert(0, velocity)
+        return Operation(goal)
+
     def move_on_line(self, p1: TargetXY, p2: TargetXY, distance_from_p1: float,
                      target_theta: TargetTheta) -> 'Operation':
         line = ConstraintLine()

--- a/consai_examples/consai_examples/operation.py
+++ b/consai_examples/consai_examples/operation.py
@@ -20,6 +20,7 @@ from consai_msgs.msg import ConstraintPose
 from consai_msgs.msg import ConstraintTheta
 from consai_msgs.msg import ConstraintXY
 from consai_msgs.msg import State2D
+from consai_msgs.msg import RobotControlMsg
 from consai_tools.hasher import robot_control_hasher
 from copy import deepcopy
 from typing import NamedTuple
@@ -143,18 +144,18 @@ class TargetTheta(NamedTuple):
 
 
 class Operation():
-    def __init__(self, goal: RobotControl.Goal = None) -> None:
+    def __init__(self, goal: RobotControlMsg = None) -> None:
         if goal:
             self._goal = goal
         else:
-            self._goal = RobotControl.Goal()
+            self._goal = RobotControlMsg()
             self._goal.keep_control = True
 
-    def get_goal(self) -> RobotControl.Goal:
+    def get_goal(self) -> RobotControlMsg:
         return self._goal
 
     def get_hash(self) -> int:
-        return robot_control_hasher.hash_goal(self._goal)
+        return robot_control_hasher.hash_robot_control(self._goal)
 
     def halt(self) -> 'Operation':
         goal = deepcopy(self._goal)

--- a/consai_examples/consai_examples/operation.py
+++ b/consai_examples/consai_examples/operation.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from consai_msgs.action import RobotControl
 from consai_msgs.msg import ConstraintLine
 from consai_msgs.msg import ConstraintObject
 from consai_msgs.msg import ConstraintPose
@@ -298,7 +297,7 @@ class Operation():
 
 
 class OneShotOperation(Operation):
-    def __init__(self, goal: RobotControl.Goal = None) -> None:
+    def __init__(self, goal: RobotControlMsg = None) -> None:
         super().__init__(goal)
 
         # 目標姿勢にたどり着いたら制御を終える

--- a/consai_examples/consai_examples/robot_operator.py
+++ b/consai_examples/consai_examples/robot_operator.py
@@ -130,7 +130,9 @@ class RobotOperator(Node):
         self.get_logger().debug(
             'New operation for Robot {}'.format(robot_id))
 
-        # self._set_goal(robot_id, operation.get_goal())
+        if self._stop_game_velocity_has_enabled[robot_id]:
+            operation = operation.restrict_velocity_xy(self.STOP_GAME_VELOCITY)
+
         self._pub_robot_control[robot_id].publish(operation.get_goal())
         self._prev_operation_hash[robot_id] = hash_goal
 

--- a/consai_examples/consai_examples/robot_operator.py
+++ b/consai_examples/consai_examples/robot_operator.py
@@ -15,14 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from functools import partial
-
 from consai_examples.operation import Operation
-from consai_msgs.action import RobotControl
 from consai_msgs.msg import NamedTargets
 from consai_msgs.msg import RobotControlMsg
 from consai_msgs.msg import State2D
-from rclpy.action import ActionClient
 from rclpy.node import Node
 import time
 
@@ -42,17 +38,12 @@ class RobotOperator(Node):
         if target_is_yellow:
             team_color = 'yellow'
         for i in range(ROBOT_NUM):
-            action_name = team_color + str(i) + '/control'
-            self._action_clients.append(ActionClient(self, RobotControl, action_name))
             self._pub_robot_control.append(
                 self.create_publisher(RobotControlMsg, team_color + str(i) + '/control', 1))
 
         self._robot_is_free = [True] * ROBOT_NUM
-        self._send_goal_future = [None] * ROBOT_NUM
-        self._get_result_future = [None] * ROBOT_NUM
         self._target_is_yellow = target_is_yellow
         self._stop_game_velocity_has_enabled = [False] * ROBOT_NUM
-        self._avoid_obstacles_enabled = [True] * ROBOT_NUM
         self._prev_operation_timestamp = [0] * ROBOT_NUM
         self._prev_operation_hash = [None] * ROBOT_NUM
 
@@ -71,12 +62,6 @@ class RobotOperator(Node):
 
     def disable_stop_game_velocity(self, robot_id):
         self._stop_game_velocity_has_enabled[robot_id] = False
-
-    def enable_avoid_obstacles(self, robot_id):
-        self._avoid_obstacles_enabled[robot_id] = True
-
-    def disable_avoid_obstacles(self, robot_id):
-        self._avoid_obstacles_enabled[robot_id] = False
 
     def target_is_yellow(self):
         # 操作するロボットのチームカラーがyellowならtrue、blueならfalseを返す
@@ -112,12 +97,6 @@ class RobotOperator(Node):
             msg.pose.append(pose)
         self._pub_named_targets.publish(msg)
 
-    def stop(self, robot_id):
-        # 指定されたIDの制御を停止する
-        goal_msg = RobotControl.Goal()
-        goal_msg.stop = True
-        return self._set_goal(robot_id, goal_msg)
-
     def reset_operation(self, robot_id: int) -> None:
         self._prev_operation_hash[robot_id] = None
         self._prev_operation_timestamp[robot_id] = 0.0
@@ -143,47 +122,3 @@ class RobotOperator(Node):
             self.get_logger().warn(
                 'Robot {} is operated too frequently'.format(robot_id))
         self._prev_operation_timestamp[robot_id] = present_time
-
-    def _set_goal(self, robot_id, goal_msg):
-        # アクションのゴールを設定する
-        if not self._action_clients[robot_id].wait_for_server(5):
-            self.get_logger().error('TIMEOUT: wait_for_server')
-            return False
-
-        if self._stop_game_velocity_has_enabled[robot_id]:
-            goal_msg.max_velocity_xy.append(self.STOP_GAME_VELOCITY)
-
-        goal_msg.avoid_obstacles = self._avoid_obstacles_enabled[robot_id]
-
-        self._send_goal_future[robot_id] = self._action_clients[robot_id].send_goal_async(
-            goal_msg, feedback_callback=partial(self._feedback_callback, robot_id=robot_id))
-
-        self._send_goal_future[robot_id].add_done_callback(
-            partial(self._goal_response_callback, robot_id=robot_id))
-        self._robot_is_free[robot_id] = False
-
-    def _goal_response_callback(self, future, robot_id):
-        # アクションサーバへゴールを送信した後の応答を受信したら実行される関数
-        goal_handle = future.result()
-
-        if not goal_handle.accepted:
-            self.get_logger().info('Goal rejected')
-            self._robot_is_free[robot_id] = True
-            return
-
-        self.get_logger().debug('Goal accepted')
-        self._get_result_future[robot_id] = goal_handle.get_result_async()
-        self._get_result_future[robot_id].add_done_callback(
-            partial(self._get_result_callback, robot_id=robot_id))
-
-    def _feedback_callback(self, feedback_msg, robot_id):
-        # アクションサーバからのフィードバックを受信したら実行される関数
-        feedback = feedback_msg.feedback
-        (feedback)
-
-    def _get_result_callback(self, future, robot_id):
-        # アクションサーバからの行動完了通知を受信したら実行される関数
-        result = future.result().result
-        self.get_logger().debug('RobotId: {}, Result: {}, Message: {}'.format(
-            robot_id, result.success, result.message))
-        self._robot_is_free[robot_id] = True

--- a/consai_examples/consai_examples/robot_operator.py
+++ b/consai_examples/consai_examples/robot_operator.py
@@ -20,6 +20,7 @@ from functools import partial
 from consai_examples.operation import Operation
 from consai_msgs.action import RobotControl
 from consai_msgs.msg import NamedTargets
+from consai_msgs.msg import RobotControlMsg
 from consai_msgs.msg import State2D
 from rclpy.action import ActionClient
 from rclpy.node import Node
@@ -36,12 +37,15 @@ class RobotOperator(Node):
 
         ROBOT_NUM = 16
         self._action_clients = []
+        self._pub_robot_control = []
         team_color = 'blue'
         if target_is_yellow:
             team_color = 'yellow'
         for i in range(ROBOT_NUM):
             action_name = team_color + str(i) + '/control'
             self._action_clients.append(ActionClient(self, RobotControl, action_name))
+            self._pub_robot_control.append(
+                self.create_publisher(RobotControlMsg, team_color + str(i) + '/control', 1))
 
         self._robot_is_free = [True] * ROBOT_NUM
         self._send_goal_future = [None] * ROBOT_NUM
@@ -126,7 +130,8 @@ class RobotOperator(Node):
         self.get_logger().debug(
             'New operation for Robot {}'.format(robot_id))
 
-        self._set_goal(robot_id, operation.get_goal())
+        # self._set_goal(robot_id, operation.get_goal())
+        self._pub_robot_control[robot_id].publish(operation.get_goal())
         self._prev_operation_hash[robot_id] = hash_goal
 
         # 短い期間でoperateする場合は警告を出す

--- a/consai_msgs/CMakeLists.txt
+++ b/consai_msgs/CMakeLists.txt
@@ -31,6 +31,7 @@ set(msg_files
   "msg/GoalPoses.msg"
   "msg/NamedTargets.msg"
   "msg/ParsedReferee.msg"
+  "msg/RobotControlMsg.msg"
   "msg/RobotLocalVelocities.msg"
   "msg/RobotLocalVelocity.msg"
   "msg/State2D.msg"

--- a/consai_msgs/msg/RobotControlMsg.msg
+++ b/consai_msgs/msg/RobotControlMsg.msg
@@ -1,0 +1,42 @@
+# 制御を停止する場合はstopをtrue
+# actionは瞬時に完了する
+bool stop false
+# 目標値に到達しても制御を続けてほしいときはtrue
+# actionは瞬時に完了する
+bool keep_control false
+
+# XY方向の最大速度m/s を制限する
+# STOPゲーム中は走行速度を抑えなくてはならない
+float64[<=1] max_velocity_xy
+
+# 移動の目標値
+ConstraintPose[<=1] pose
+ConstraintLine[<=1] line
+
+# ボール操作関連のフラグ
+# kick_enable = trueでボールを蹴る
+bool kick_enable false
+# kick_pass = falseで最大速度でボールを蹴る
+# kick_pass = trueで低速度でボールを蹴る
+bool kick_pass false
+# kick_setplay = true でセットプレイ用の落ち着いたキックを実行する
+bool kick_setplay false
+# キックの目標地点
+ConstraintXY kick_target
+
+# dribble_enable = trueで、dribble_targetに向かってボールを運ぶ
+bool dribble_enable false
+bool ball_boy_dribble_enable false
+ConstraintXY dribble_target
+
+# 転がっているボールを受け取るときはtrue
+bool receive_ball false
+
+# リフレクトシュート
+bool reflect_shoot false
+
+bool avoid_obstacles true  # 衝突回避は安全のためデフォルトでtrue
+bool avoid_placement_area false  # 回避の機会は限定的なのでデフォルトでfalse
+State2D placement_pos
+bool avoid_ball false  # ボールを避ける機会は限定的なのでデフォルトでfalse
+bool avoid_pushing_robots false  # ロボット同士の押し合いを避ける機会は限定的なのでデフォルトでfalse

--- a/consai_robot_controller/include/consai_robot_controller/controller_component.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/controller_component.hpp
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include "consai_frootspi_msgs/msg/robot_command.hpp"
-#include "consai_msgs/action/robot_control.hpp"
 #include "consai_msgs/msg/goal_pose.hpp"
 #include "consai_msgs/msg/goal_poses.hpp"
 #include "consai_msgs/msg/named_targets.hpp"
@@ -47,9 +46,7 @@ using GoalPoses = consai_msgs::msg::GoalPoses;
 using NamedTargets = consai_msgs::msg::NamedTargets;
 using State = consai_msgs::msg::State2D;
 using RobotCommand = consai_frootspi_msgs::msg::RobotCommand;
-using RobotControl = consai_msgs::action::RobotControl;
 using RobotControlMsg = consai_msgs::msg::RobotControlMsg;
-using GoalHandleRobotControl = rclcpp_action::ServerGoalHandle<RobotControl>;
 using GeometryData = robocup_ssl_msgs::msg::GeometryData;
 using ParsedReferee = consai_msgs::msg::ParsedReferee;
 using Referee = robocup_ssl_msgs::msg::Referee;
@@ -69,16 +66,6 @@ protected:
   void on_timer_pub_goal_poses();
 
 private:
-  rclcpp_action::GoalResponse handle_goal(
-    const rclcpp_action::GoalUUID & uuid,
-    std::shared_ptr<const RobotControl::Goal> goal,
-    const unsigned int robot_id);
-  rclcpp_action::CancelResponse handle_cancel(
-    const std::shared_ptr<GoalHandleRobotControl> goal_handle,
-    const unsigned int robot_id);
-  void handle_accepted(
-    std::shared_ptr<GoalHandleRobotControl> goal_handle,
-    const unsigned int robot_id);
   State limit_world_velocity(
     const State & velocity, const double & max_velocity_xy,
     const double & max_velocity_theta) const;
@@ -86,17 +73,12 @@ private:
     const State & velocity, const State & last_velocity,
     const rclcpp::Duration & dt) const;
   bool arrived(const TrackedRobot & my_robot, const State & goal_pose);
-  bool switch_to_stop_control_mode(
-    const unsigned int robot_id, const bool success, const std::string & error_msg);
+  bool publish_stop_command(const unsigned int robot_id);
 
   std::vector<rclcpp::Publisher<RobotCommand>::SharedPtr> pub_command_;
-  std::vector<rclcpp_action::Server<RobotControl>::SharedPtr> server_control_;
   std::vector<rclcpp::Subscription<RobotControlMsg>::SharedPtr> sub_robot_control_;
   std::vector<rclcpp::Time> last_update_time_;
   std::vector<rclcpp::TimerBase::SharedPtr> timer_pub_control_command_;
-  std::vector<bool> control_enable_;
-  std::vector<bool> need_response_;
-  std::vector<std::shared_ptr<GoalHandleRobotControl>> goal_handle_;
   std::vector<State> last_world_vel_;
 
   std::shared_ptr<consai_robot_controller::FieldInfoParser> parser_;

--- a/consai_robot_controller/include/consai_robot_controller/controller_component.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/controller_component.hpp
@@ -26,6 +26,7 @@
 #include "consai_msgs/msg/goal_poses.hpp"
 #include "consai_msgs/msg/named_targets.hpp"
 #include "consai_msgs/msg/parsed_referee.hpp"
+#include "consai_msgs/msg/robot_control_msg.hpp"
 #include "consai_msgs/msg/state2_d.hpp"
 #include "consai_robot_controller/field_info_parser.hpp"
 #include "consai_robot_controller/visibility_control.h"
@@ -47,6 +48,7 @@ using NamedTargets = consai_msgs::msg::NamedTargets;
 using State = consai_msgs::msg::State2D;
 using RobotCommand = consai_frootspi_msgs::msg::RobotCommand;
 using RobotControl = consai_msgs::action::RobotControl;
+using RobotControlMsg = consai_msgs::msg::RobotControlMsg;
 using GoalHandleRobotControl = rclcpp_action::ServerGoalHandle<RobotControl>;
 using GeometryData = robocup_ssl_msgs::msg::GeometryData;
 using ParsedReferee = consai_msgs::msg::ParsedReferee;
@@ -54,6 +56,7 @@ using Referee = robocup_ssl_msgs::msg::Referee;
 using TrackedFrame = robocup_ssl_msgs::msg::TrackedFrame;
 using TrackedRobot = robocup_ssl_msgs::msg::TrackedRobot;
 using GoalPosesMap = std::map<unsigned int, GoalPose>;
+using RobotControlMap = std::map<unsigned int, RobotControlMsg::SharedPtr>;
 
 class Controller : public rclcpp::Node
 {
@@ -88,6 +91,7 @@ private:
 
   std::vector<rclcpp::Publisher<RobotCommand>::SharedPtr> pub_command_;
   std::vector<rclcpp_action::Server<RobotControl>::SharedPtr> server_control_;
+  std::vector<rclcpp::Subscription<RobotControlMsg>::SharedPtr> sub_robot_control_;
   std::vector<rclcpp::Time> last_update_time_;
   std::vector<rclcpp::TimerBase::SharedPtr> timer_pub_control_command_;
   std::vector<bool> control_enable_;
@@ -108,6 +112,8 @@ private:
   rclcpp::Publisher<GoalPoses>::SharedPtr pub_final_goal_poses_;
   rclcpp::TimerBase::SharedPtr timer_pub_goal_poses_;
   std::shared_ptr<VisualizationDataHandler> vis_data_handler_;
+
+  RobotControlMap robot_control_map_;
   GoalPosesMap goal_poses_map_;
   GoalPosesMap final_goal_poses_map_;
   bool team_is_yellow_;

--- a/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
@@ -18,7 +18,6 @@
 #include <memory>
 #include <string>
 
-#include "consai_msgs/action/robot_control.hpp"
 #include "consai_msgs/msg/named_targets.hpp"
 #include "consai_msgs/msg/parsed_referee.hpp"
 #include "consai_msgs/msg/robot_control_msg.hpp"
@@ -39,7 +38,6 @@
 namespace consai_robot_controller
 {
 
-using RobotControl = consai_msgs::action::RobotControl;
 using RobotControlMsg = consai_msgs::msg::RobotControlMsg;
 using NamedTargets = consai_msgs::msg::NamedTargets;
 using State = consai_msgs::msg::State2D;

--- a/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
@@ -21,6 +21,7 @@
 #include "consai_msgs/action/robot_control.hpp"
 #include "consai_msgs/msg/named_targets.hpp"
 #include "consai_msgs/msg/parsed_referee.hpp"
+#include "consai_msgs/msg/robot_control_msg.hpp"
 #include "consai_msgs/msg/state2_d.hpp"
 #include "consai_robot_controller/constraint_parser.hpp"
 #include "consai_robot_controller/detection_extractor.hpp"
@@ -39,6 +40,7 @@ namespace consai_robot_controller
 {
 
 using RobotControl = consai_msgs::action::RobotControl;
+using RobotControlMsg = consai_msgs::msg::RobotControlMsg;
 using NamedTargets = consai_msgs::msg::NamedTargets;
 using State = consai_msgs::msg::State2D;
 using GeometryData = robocup_ssl_msgs::msg::GeometryData;
@@ -59,19 +61,19 @@ public:
   void set_referee(const Referee::SharedPtr referee);
   void set_parsed_referee(const ParsedReferee::SharedPtr parsed_referee);
   void set_named_targets(const NamedTargets::SharedPtr msg);
-  bool is_parsable(const std::shared_ptr<const RobotControl::Goal> goal) const;
+  bool is_parsable(const RobotControlMsg::SharedPtr goal) const;
   bool parse_goal(
-    const std::shared_ptr<const RobotControl::Goal> goal,
+    const RobotControlMsg::SharedPtr goal,
     const TrackedRobot & my_robot, State & parsed_pose, State & final_goal_pose,
     double & kick_power, double & dribble_power);
   State modify_goal_pose_to_avoid_obstacles(
-    const std::shared_ptr<const RobotControl::Goal> goal,
+    const RobotControlMsg::SharedPtr goal,
     const TrackedRobot & my_robot,
     const State & goal_pose, const State & final_goal_pose) const;
 
 private:
   bool parse_constraints(
-    const std::shared_ptr<const RobotControl::Goal> goal, State & parsed_pose) const;
+    const RobotControlMsg::SharedPtr goal, State & parsed_pose) const;
 
   bool team_is_yellow_ = false;
   bool invert_ = false;

--- a/consai_robot_controller/include/consai_robot_controller/obstacle/obstacle_observer.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/obstacle/obstacle_observer.hpp
@@ -17,7 +17,6 @@
 
 #include <memory>
 
-#include "consai_msgs/action/robot_control.hpp"
 #include "consai_msgs/msg/robot_control_msg.hpp"
 #include "consai_robot_controller/detection_extractor.hpp"
 #include "consai_robot_controller/obstacle/obstacle_environment.hpp"
@@ -26,7 +25,6 @@
 namespace obstacle
 {
 
-using RobotControl = consai_msgs::action::RobotControl;
 using RobotControlMsg = consai_msgs::msg::RobotControlMsg;
 using TrackedRobot = robocup_ssl_msgs::msg::TrackedRobot;
 

--- a/consai_robot_controller/include/consai_robot_controller/obstacle/obstacle_observer.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/obstacle/obstacle_observer.hpp
@@ -18,6 +18,7 @@
 #include <memory>
 
 #include "consai_msgs/action/robot_control.hpp"
+#include "consai_msgs/msg/robot_control_msg.hpp"
 #include "consai_robot_controller/detection_extractor.hpp"
 #include "consai_robot_controller/obstacle/obstacle_environment.hpp"
 #include "robocup_ssl_msgs/msg/tracked_robot.hpp"
@@ -26,6 +27,7 @@ namespace obstacle
 {
 
 using RobotControl = consai_msgs::action::RobotControl;
+using RobotControlMsg = consai_msgs::msg::RobotControlMsg;
 using TrackedRobot = robocup_ssl_msgs::msg::TrackedRobot;
 
 class ObstacleObserver
@@ -35,7 +37,7 @@ public:
     const std::shared_ptr<parser::DetectionExtractor> & detection_extractor);
 
   ObstacleEnvironment get_obstacle_environment(
-    const std::shared_ptr<const RobotControl::Goal> goal,
+    const RobotControlMsg::SharedPtr goal,
     const TrackedRobot & my_robot) const;
 
 private:

--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -54,15 +54,14 @@ void FieldInfoParser::set_named_targets(const NamedTargets::SharedPtr msg)
   constraint_parser_->set_named_targets(msg);
 }
 
-bool FieldInfoParser::is_parsable(
-  const std::shared_ptr<const RobotControl::Goal> goal) const
+bool FieldInfoParser::is_parsable(const RobotControlMsg::SharedPtr goal) const
 {
   State target_pose;
   return parse_constraints(goal, target_pose);
 }
 
 bool FieldInfoParser::parse_goal(
-  const std::shared_ptr<const RobotControl::Goal> goal,
+  const RobotControlMsg::SharedPtr goal,
   const TrackedRobot & my_robot, State & parsed_pose, State & final_goal_pose,
   double & kick_power, double & dribble_power)
 {
@@ -140,7 +139,7 @@ bool FieldInfoParser::parse_goal(
 }
 
 State FieldInfoParser::modify_goal_pose_to_avoid_obstacles(
-  const std::shared_ptr<const RobotControl::Goal> goal,
+  const RobotControlMsg::SharedPtr goal,
   const TrackedRobot & my_robot,
   const State & goal_pose, const State & final_goal_pose) const
 {
@@ -176,7 +175,7 @@ State FieldInfoParser::modify_goal_pose_to_avoid_obstacles(
 }
 
 bool FieldInfoParser::parse_constraints(
-  const std::shared_ptr<const RobotControl::Goal> goal, State & parsed_pose) const
+  const RobotControlMsg::SharedPtr goal, State & parsed_pose) const
 {
   if (goal->pose.size() > 0) {
     if (constraint_parser_->parse_constraint_pose(goal->pose[0], parsed_pose)) {

--- a/consai_robot_controller/src/obstacle/obstacle_observer.cpp
+++ b/consai_robot_controller/src/obstacle/obstacle_observer.cpp
@@ -40,7 +40,7 @@ ObstacleObserver::ObstacleObserver(
 }
 
 ObstacleEnvironment ObstacleObserver::get_obstacle_environment(
-  const std::shared_ptr<const RobotControl::Goal> goal,
+  const RobotControlMsg::SharedPtr goal,
   const TrackedRobot & my_robot) const
 {
   // constexpr ObstRadius BALL_RADIUS(0.0215);

--- a/consai_robot_controller/test/obstacle_observer_test.cpp
+++ b/consai_robot_controller/test/obstacle_observer_test.cpp
@@ -14,7 +14,6 @@
 
 #include <gtest/gtest.h>
 #include <memory>
-#include "consai_msgs/action/robot_control.hpp"
 #include "consai_msgs/msg/robot_control_msg.hpp"
 #include "consai_robot_controller/obstacle/obstacle_observer.hpp"
 #include "consai_robot_controller/detection_extractor.hpp"
@@ -24,7 +23,6 @@
 #include "robocup_ssl_msgs/msg/tracked_robot.hpp"
 
 
-using RobotControl = consai_msgs::action::RobotControl;
 using RobotControlMsg = consai_msgs::msg::RobotControlMsg;
 using RobotId = robocup_ssl_msgs::msg::RobotId;
 using TrackedBall = robocup_ssl_msgs::msg::TrackedBall;

--- a/consai_robot_controller/test/obstacle_observer_test.cpp
+++ b/consai_robot_controller/test/obstacle_observer_test.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 #include <memory>
 #include "consai_msgs/action/robot_control.hpp"
+#include "consai_msgs/msg/robot_control_msg.hpp"
 #include "consai_robot_controller/obstacle/obstacle_observer.hpp"
 #include "consai_robot_controller/detection_extractor.hpp"
 #include "robocup_ssl_msgs/msg/robot_id.hpp"
@@ -24,6 +25,7 @@
 
 
 using RobotControl = consai_msgs::action::RobotControl;
+using RobotControlMsg = consai_msgs::msg::RobotControlMsg;
 using RobotId = robocup_ssl_msgs::msg::RobotId;
 using TrackedBall = robocup_ssl_msgs::msg::TrackedBall;
 using TrackedFrame = robocup_ssl_msgs::msg::TrackedFrame;
@@ -45,7 +47,7 @@ TEST(TestObstacleObserver, obstacle_robot) {
   auto detection_extractor = std::make_shared<parser::DetectionExtractor>();
   auto observer = std::make_shared<obstacle::ObstacleObserver>(detection_extractor);
 
-  auto goal = std::make_shared<RobotControl::Goal>();
+  auto goal = std::make_shared<RobotControlMsg>();
   goal->avoid_obstacles = true;
   auto my_robot = make_robot(0, RobotId::TEAM_COLOR_BLUE, 0.0, 0.0);
 

--- a/consai_tools/consai_tools/hasher/robot_control_hasher.py
+++ b/consai_tools/consai_tools/hasher/robot_control_hasher.py
@@ -14,6 +14,7 @@
 
 
 from consai_msgs.action import RobotControl
+from consai_msgs.msg import RobotControlMsg
 from consai_tools.hasher import constraint_hasher as hasher
 
 
@@ -42,5 +43,34 @@ def hash_goal(goal: RobotControl.Goal) -> int:
         goal.placement_pos.y,
         goal.avoid_ball,
         goal.avoid_pushing_robots,
+    )
+    return hash(target)
+
+
+def hash_robot_control(msg: RobotControlMsg) -> int:
+    pose_hash = tuple(hasher.hash_constraint_pose(pose) for pose in msg.pose)
+    line_hash = tuple(hasher.hash_constraint_line(line) for line in msg.line)
+
+    target = (
+        msg.stop,
+        msg.keep_control,
+        tuple(msg.max_velocity_xy),
+        pose_hash,
+        line_hash,
+        msg.kick_enable,
+        msg.kick_pass,
+        msg.kick_setplay,
+        hasher.hash_constraint_xy(msg.kick_target),
+        msg.dribble_enable,
+        msg.ball_boy_dribble_enable,
+        hasher.hash_constraint_xy(msg.dribble_target),
+        msg.receive_ball,
+        msg.reflect_shoot,
+        msg.avoid_obstacles,
+        msg.avoid_placement_area,
+        msg.placement_pos.x,
+        msg.placement_pos.y,
+        msg.avoid_ball,
+        msg.avoid_pushing_robots,
     )
     return hash(target)


### PR DESCRIPTION

## 現状の問題点
game側で、ロボットの目標位置を動的に変更することが多くなっています。

RobotControl.actionでは、動的な目標位置変更に対応することが難しいです。

NamedTargetを使えば可能ですが、実装としてわかりにくいです。

## 解決策

Action通信をやめてTopic通信を採用します。

## 懸念点

Actionならではの、成功失敗判定や、行動中のフィードバックが使えなくなります。（今もあまり使ってないのですが。。。）

この対策として、行動完了トピックをcontrollerから配信予定です。別PRで対応します。

## 本PRのテスト方法

- シナリオテストが通ることを確認します
- 試合プログラムを実行し、大きな挙動変化が無いことを確認します。