### PR TITLE
Add shoot_tactics

### DIFF
--- a/consai_examples/consai_examples/decisions/attacker.py
+++ b/consai_examples/consai_examples/decisions/attacker.py
@@ -51,22 +51,27 @@ class AttackerDecision(DecisionBase):
         self._operator.operate(robot_id, chase_ball)
 
     def inplay(self, robot_id):
-        move_to_ball = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
-        move_to_ball = move_to_ball.with_ball_receiving()
-        move_to_ball = move_to_ball.with_reflecting_to(TargetXY.their_goal())
+        wait = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
+        wait = wait.with_ball_receiving()
+        wait = wait.with_reflecting_to(TargetXY.their_goal())
         # ボールが自分ディフェンスエリアにあるときは、ボールと同じ軸上に移動する
         if self._field_observer.ball_position().is_in_our_defense_area() or \
            self._field_observer.ball_position().is_outside_of_left():
-            move_to_ball = move_to_ball.overwrite_pose_x(-3.0)
-            self._operator.operate(robot_id, move_to_ball)
+            wait = wait.overwrite_pose_x(-3.0)
+            self._operator.operate(robot_id, wait)
             return
 
         # ボールが相手ディフェンスエリアにあるときは、ボールと同じ軸上に移動する
         if self._field_observer.ball_position().is_in_their_defense_area() or \
            self._field_observer.ball_position().is_outside_of_right():
-            move_to_ball = move_to_ball.overwrite_pose_x(3.0)
-            self._operator.operate(robot_id, move_to_ball)
+            wait = wait.overwrite_pose_x(3.0)
+            self._operator.operate(robot_id, wait)
             return
+
+        move_to_ball = Operation().move_on_line(
+            TargetXY.ball(), TargetXY.our_robot(robot_id), 0.05, TargetTheta.look_ball())
+        move_to_ball = move_to_ball.with_ball_receiving()
+        move_to_ball = move_to_ball.with_reflecting_to(TargetXY.their_goal())
 
         # シュートできる場合はシュートする
         shoot_pos_list = self._field_observer.pass_shoot().get_shoot_pos_list()

--- a/consai_examples/consai_examples/decisions/attacker.py
+++ b/consai_examples/consai_examples/decisions/attacker.py
@@ -167,15 +167,17 @@ class AttackerDecision(DecisionBase):
         # ボールがフィールド外にある場合は、壁に向かってボールを蹴る
         if self._field_observer.ball_position().is_outside():
             kick_pos = self._kick_pos_to_reflect_on_wall(placement_pos)
-            move_to_ball = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
-            put_ball_back = move_to_ball.with_shooting_for_setplay_to(
+            move_to_ball = Operation().move_on_line(
+                TargetXY.ball(), TargetXY.our_robot(robot_id), 0.05, TargetTheta.look_ball())
+            put_ball_back = move_to_ball.with_shooting_to(
                 TargetXY.value(kick_pos.x, kick_pos.y))
             self._operator.operate(robot_id, put_ball_back)
             return
 
         if self._field_observer.ball_placement().is_far_from(placement_pos):
             # ボール位置が配置目標位置から離れているときはパスする
-            move_to_ball = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
+            move_to_ball = Operation().move_on_line(
+                TargetXY.ball(), TargetXY.our_robot(robot_id), 0.05, TargetTheta.look_ball())
             passing = move_to_ball.with_passing_to(TargetXY.value(
                 placement_pos.x, placement_pos.y))
             self._operator.operate(robot_id, passing)

--- a/consai_examples/consai_examples/observer/pass_shoot_observer.py
+++ b/consai_examples/consai_examples/observer/pass_shoot_observer.py
@@ -158,7 +158,7 @@ class PassShootObserver:
         else:
             return search(pos, self._their_robots)
 
-    def _search_shoot_pos_list(self) -> list[State2D]:
+    def _search_shoot_pos_list(self, search_ours=False) -> list[State2D]:
         # ボールからの直線上にロボットがいないシュート位置リストを返す
         TOLERANCE = 0.1  # ロボット半径 + alpha
 
@@ -172,7 +172,7 @@ class PassShootObserver:
             return False
 
         for target in self._goal_pos_list:
-            if obstacle_exists(target, self._our_robots):
+            if obstacle_exists(target, self._our_robots) and search_ours:
                 continue
             if obstacle_exists(target, self._their_robots):
                 continue

--- a/consai_robot_controller/CMakeLists.txt
+++ b/consai_robot_controller/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(controller_component SHARED
   src/obstacle/obstacle_observer.cpp
   src/tactic/ball_boy_tactics.cpp
   src/tactic/dribble_tactics.cpp
+  src/tactic/shoot_tactics.cpp
   src/tactic/tactic_control_ball.cpp
   src/tactic/tactic_obstacle_avoidance.cpp
   src/tools/control_tools.cpp

--- a/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
@@ -27,6 +27,7 @@
 #include "consai_robot_controller/obstacle/obstacle_environment.hpp"
 #include "consai_robot_controller/tactic/ball_boy_tactics.hpp"
 #include "consai_robot_controller/tactic/dribble_tactics.hpp"
+#include "consai_robot_controller/tactic/shoot_tactics.hpp"
 #include "consai_robot_controller/tactic/tactic_control_ball.hpp"
 #include "consai_robot_controller/tactic/tactic_obstacle_avoidance.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -82,6 +83,7 @@ private:
   std::shared_ptr<ParsedReferee> parsed_referee_;
   tactics::BallBoyTactics ball_boy_tactics_;
   dribble_tactics::DribbleTactics dribble_tactics_;
+  shoot_tactics::ShootTactics shoot_tactics_;
   std::shared_ptr<parser::ConstraintParser> constraint_parser_;
   std::shared_ptr<tactic::ControlBall> tactic_control_ball_;
   std::shared_ptr<tactic::ObstacleAvoidance> tactic_obstacle_avoidance_;

--- a/consai_robot_controller/include/consai_robot_controller/tactic/shoot_tactics.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/tactic/shoot_tactics.hpp
@@ -1,0 +1,57 @@
+// Copyright 2024 Roots
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONSAI_ROBOT_CONTROLLER__TACTIC__SHOOT_TACTICS_HPP_
+#define CONSAI_ROBOT_CONTROLLER__TACTIC__SHOOT_TACTICS_HPP_
+
+#include <chrono>
+#include <functional>
+#include <map>
+#include <string>
+
+#include "consai_msgs/msg/state2_d.hpp"
+#include "consai_robot_controller/tactic/tactic_data_set.hpp"
+#include "robocup_ssl_msgs/msg/tracked_ball.hpp"
+#include "robocup_ssl_msgs/msg/tracked_robot.hpp"
+
+namespace shoot_tactics
+{
+
+using Time = std::chrono::system_clock::time_point;
+using State = consai_msgs::msg::State2D;
+using TrackedBall = robocup_ssl_msgs::msg::TrackedBall;
+using TrackedRobot = robocup_ssl_msgs::msg::TrackedRobot;
+using RobotID = unsigned int;
+using TacticName = std::string;
+using TacticDataSet = tactics::TacticDataSet;
+
+class ShootTactics
+{
+public:
+  ShootTactics();
+  ~ShootTactics() = default;
+  bool update(
+    const State & shoot_target, const TrackedRobot & my_robot, const TrackedBall & ball,
+    const bool & is_pass,
+    State & parsed_pose, double & parsed_kick_power, double & parsed_dribble_power);
+
+private:
+  std::map<RobotID, TacticName> tactic_name_;
+  std::map<RobotID, Time> tactic_time_;
+  std::map<TacticName, std::function<TacticName(TacticDataSet & data_set)>> tactic_functions_;
+};
+
+}  // namespace shoot_tactics
+
+#endif  // CONSAI_ROBOT_CONTROLLER__TACTIC__SHOOT_TACTICS_HPP_

--- a/consai_robot_controller/include/consai_robot_controller/tactic/tactic_data_set.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/tactic/tactic_data_set.hpp
@@ -53,6 +53,7 @@ public:
   {
     parsed_dribble_power_ = parsed_dribble_power;
   }
+  void set_pass(const bool & is_pass) {is_pass_ = is_pass;}
 
   TrackedRobot get_my_robot(void) {return my_robot_;}
   TrackedBall get_ball(void) {return ball_;}
@@ -60,6 +61,7 @@ public:
   State get_parsed_pose(void) {return parsed_pose_;}
   double get_parsed_kick_power(void) {return parsed_kick_power_;}
   double get_parsed_dribble_power(void) {return parsed_dribble_power_;}
+  bool is_pass(void) {return is_pass_;}
 
 private:
   TrackedRobot my_robot_;
@@ -68,6 +70,7 @@ private:
   State parsed_pose_;
   double parsed_kick_power_;
   double parsed_dribble_power_;
+  bool is_pass_ = false;
 };
 
 }  // namespace tactics

--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -116,11 +116,8 @@ bool FieldInfoParser::parse_goal(
       }
     }
 
-    if (tactic_control_ball_->kick_ball(
-        kick_target, my_robot, ball, goal->kick_pass, parsed_pose, kick_power, dribble_power))
-    {
-      return true;
-    }
+    shoot_tactics_.update(kick_target, my_robot, ball, goal->kick_pass, parsed_pose, kick_power, dribble_power);
+    return true;
   }
 
   if (goal->dribble_enable && has_dribble_target) {

--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -116,7 +116,9 @@ bool FieldInfoParser::parse_goal(
       }
     }
 
-    shoot_tactics_.update(kick_target, my_robot, ball, goal->kick_pass, parsed_pose, kick_power, dribble_power);
+    shoot_tactics_.update(
+      kick_target, my_robot, ball, goal->kick_pass, parsed_pose, kick_power,
+      dribble_power);
     return true;
   }
 

--- a/consai_robot_controller/src/tactic/shoot_tactics.cpp
+++ b/consai_robot_controller/src/tactic/shoot_tactics.cpp
@@ -1,0 +1,174 @@
+// Copyright 2024 Roots
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "consai_robot_controller/tactic/shoot_tactics.hpp"
+#include "consai_tools/geometry_tools.hpp"
+
+namespace shoot_tactics
+{
+
+namespace tools = geometry_tools;
+namespace chrono = std::chrono;
+
+static constexpr double ROBOT_RADIUS = 0.09;  // ロボットの半径
+static constexpr double DRIBBLE_CATCH = 1.0;
+static constexpr double DRIBBLE_RELEASE = 0.0;
+static constexpr double MAX_SHOOT_SPEED = 5.5;  // m/s
+static constexpr double WAIT_DISTANCE = 0.7;  // meters
+static constexpr auto WAIT = "WAIT";
+static constexpr auto APPROACH = "APPROACH";
+static constexpr auto CATCH = "CATCH";
+static constexpr auto ROTATE = "ROTATE";
+static constexpr auto SHOOT = "SHOOT";
+
+
+ShootTactics::ShootTactics()
+{
+  tactic_functions_[WAIT] = [this](TacticDataSet & data_set) -> TacticName {
+    // ボールが近づいてくるまで待機
+    // キックのための必須処理ではないので、削除してもOK
+    const auto robot_pose = tools::pose_state(data_set.get_my_robot());
+    const auto ball_pose = tools::pose_state(data_set.get_ball());
+
+    if (tools::distance(robot_pose, ball_pose) <= WAIT_DISTANCE) {
+      return APPROACH;
+    }
+
+    return WAIT;
+  };
+
+  tactic_functions_[APPROACH] = [this](TacticDataSet & data_set) -> TacticName {
+    // 現在位置からボールに対してまっすぐ進む
+
+    // 近づけば良いので、しきい値を大きくする
+    constexpr auto DISTANCE_THRESHOLD = 0.3;  // meters
+    const auto THETA_THRESHOLD = tools::to_radians(5.0);
+
+    const auto robot_pose = tools::pose_state(data_set.get_my_robot());
+    const auto ball_pose = tools::pose_state(data_set.get_ball());
+
+    const tools::Trans trans_BtoR(ball_pose, tools::calc_angle(ball_pose, robot_pose));
+    const auto new_pose = trans_BtoR.inverted_transform(ROBOT_RADIUS * 2.0, 0.0, -M_PI);
+
+    data_set.set_parsed_pose(new_pose);
+    data_set.set_parsed_dribble_power(DRIBBLE_RELEASE);
+
+    if (tools::is_same(robot_pose, new_pose, DISTANCE_THRESHOLD, THETA_THRESHOLD)) {
+      return CATCH;
+    }
+
+    return APPROACH;
+  };
+
+  tactic_functions_[CATCH] = [this](TacticDataSet & data_set) -> TacticName {
+    // ドリブラーを駆動させながら前進する
+    // ボールをキャッチするため、一定時間は行動を継続する
+    constexpr auto CATCHING_TIME = 0.3;  // seconds
+
+    const auto robot_pose = tools::pose_state(data_set.get_my_robot());
+    const auto ball_pose = tools::pose_state(data_set.get_ball());
+
+    const tools::Trans trans_BtoR(ball_pose, tools::calc_angle(ball_pose, robot_pose));
+    const auto new_pose = trans_BtoR.inverted_transform(ROBOT_RADIUS * 0.0, 0.0, -M_PI);
+
+    data_set.set_parsed_pose(new_pose);
+    data_set.set_parsed_dribble_power(DRIBBLE_CATCH);
+
+    const auto robot_id = data_set.get_my_robot().robot_id.id;
+    const auto elapsed =
+      chrono::duration<double>(chrono::system_clock::now() - tactic_time_[robot_id]).count();
+
+    if (elapsed > CATCHING_TIME) {
+      return ROTATE;
+    }
+
+    return CATCH;
+  };
+
+  tactic_functions_[ROTATE] = [this](TacticDataSet & data_set) -> TacticName {
+    // ボールを中心にロボットが回転移動し、ボールと目標値の直線上に移動する
+    // 目的位置をしっかり狙ったら、次の行動に移行する
+    constexpr auto DISTANCE_THRESHOLD = 0.05;  // meters
+    const auto THETA_THRESHOLD = tools::to_radians(3.0);
+
+    const auto robot_pose = tools::pose_state(data_set.get_my_robot());
+    const auto ball_pose = tools::pose_state(data_set.get_ball());
+    const auto target_pose = data_set.get_target();
+
+    const tools::Trans trans_BtoT(ball_pose, tools::calc_angle(ball_pose, target_pose));
+    const auto new_pose = trans_BtoT.inverted_transform(-ROBOT_RADIUS, 0.0, 0.0);
+
+    data_set.set_parsed_pose(new_pose);
+    data_set.set_parsed_dribble_power(DRIBBLE_CATCH);
+
+    if (tools::is_same(robot_pose, new_pose, DISTANCE_THRESHOLD, THETA_THRESHOLD)) {
+      return SHOOT;
+    }
+
+    return ROTATE;
+  };
+
+  tactic_functions_[SHOOT] = [this](TacticDataSet & data_set) -> TacticName {
+    // 目的位置に向かってシュートする
+    // ボールが離れたら終了する
+    const auto robot_pose = tools::pose_state(data_set.get_my_robot());
+    const auto ball_pose = tools::pose_state(data_set.get_ball());
+
+    data_set.set_parsed_dribble_power(DRIBBLE_RELEASE);
+    data_set.set_parsed_kick_power(MAX_SHOOT_SPEED);
+
+    if (tools::distance(robot_pose, ball_pose) > ROBOT_RADIUS * 2.0) {
+      return WAIT;
+    }
+
+    return SHOOT;
+  };
+}
+
+bool ShootTactics::update(
+  const State & shoot_target, const TrackedRobot & my_robot, const TrackedBall & ball,
+  const bool & is_pass,
+  State & parsed_pose, double & parsed_kick_power, double & parsed_dribble_power)
+{
+  const auto robot_id = my_robot.robot_id.id;
+  // If the robot is not in the map, initialize the tactic state.
+  if (tactic_name_.find(robot_id) == tactic_name_.end()) {
+    tactic_name_[robot_id] = WAIT;
+    tactic_time_[robot_id] = chrono::system_clock::now();
+  }
+
+  // ロボットボールが大きく離れたらリセットする
+  if (tools::distance(tools::pose_state(my_robot), tools::pose_state(ball)) > WAIT_DISTANCE) {
+    tactic_name_[robot_id] = WAIT;
+    tactic_time_[robot_id] = chrono::system_clock::now();
+  }
+
+  // Execute the tactic fuction.
+  TacticDataSet data_set(my_robot, ball, shoot_target, parsed_pose, parsed_kick_power, parsed_dribble_power);
+  const auto next_tactic = tactic_functions_[tactic_name_[robot_id]](data_set);
+
+  if (tactic_name_[robot_id] != next_tactic) {
+    // Reset timestamp
+    tactic_name_[robot_id] = next_tactic;
+    tactic_time_[robot_id] = chrono::system_clock::now();
+  }
+
+  parsed_pose = data_set.get_parsed_pose();
+  parsed_dribble_power = data_set.get_parsed_dribble_power();
+  parsed_kick_power = data_set.get_parsed_kick_power();
+
+  return true;
+}
+
+}  // namespace shoot_tactics

--- a/consai_robot_controller/src/tactic/shoot_tactics.cpp
+++ b/consai_robot_controller/src/tactic/shoot_tactics.cpp
@@ -15,6 +15,8 @@
 #include "consai_robot_controller/tactic/shoot_tactics.hpp"
 #include "consai_tools/geometry_tools.hpp"
 
+#include <iostream>
+
 namespace shoot_tactics
 {
 
@@ -28,7 +30,6 @@ static constexpr double MAX_SHOOT_SPEED = 5.5;  // m/s
 static constexpr double WAIT_DISTANCE = 0.7;  // meters
 static constexpr auto WAIT = "WAIT";
 static constexpr auto APPROACH = "APPROACH";
-static constexpr auto CATCH = "CATCH";
 static constexpr auto ROTATE = "ROTATE";
 static constexpr auto SHOOT = "SHOOT";
 
@@ -65,42 +66,19 @@ ShootTactics::ShootTactics()
     data_set.set_parsed_dribble_power(DRIBBLE_RELEASE);
 
     if (tools::is_same(robot_pose, new_pose, DISTANCE_THRESHOLD, THETA_THRESHOLD)) {
-      return CATCH;
+      return ROTATE;
     }
 
     return APPROACH;
   };
 
-  tactic_functions_[CATCH] = [this](TacticDataSet & data_set) -> TacticName {
-    // ドリブラーを駆動させながら前進する
-    // ボールをキャッチするため、一定時間は行動を継続する
-    constexpr auto CATCHING_TIME = 0.3;  // seconds
-
-    const auto robot_pose = tools::pose_state(data_set.get_my_robot());
-    const auto ball_pose = tools::pose_state(data_set.get_ball());
-
-    const tools::Trans trans_BtoR(ball_pose, tools::calc_angle(ball_pose, robot_pose));
-    const auto new_pose = trans_BtoR.inverted_transform(ROBOT_RADIUS * 0.0, 0.0, -M_PI);
-
-    data_set.set_parsed_pose(new_pose);
-    // data_set.set_parsed_dribble_power(DRIBBLE_CATCH);
-
-    const auto robot_id = data_set.get_my_robot().robot_id.id;
-    const auto elapsed =
-      chrono::duration<double>(chrono::system_clock::now() - tactic_time_[robot_id]).count();
-
-    if (elapsed > CATCHING_TIME) {
-      return ROTATE;
-    }
-
-    return CATCH;
-  };
 
   tactic_functions_[ROTATE] = [this](TacticDataSet & data_set) -> TacticName {
     // ボールを中心にロボットが回転移動し、ボールと目標値の直線上に移動する
     // 目的位置をしっかり狙ったら、次の行動に移行する
     constexpr auto DISTANCE_THRESHOLD = 0.05;  // meters
     const auto THETA_THRESHOLD = tools::to_radians(5.0);
+    const auto OMEGA_THRESHOLD = 0.1;  // rad/s
 
     const auto robot_pose = tools::pose_state(data_set.get_my_robot());
     const auto ball_pose = tools::pose_state(data_set.get_ball());
@@ -111,26 +89,29 @@ ShootTactics::ShootTactics()
 
     const auto robot_pose_BtoT = trans_BtoT.transform(robot_pose);
     const auto angle_robot_position = tools::calc_angle(State(), robot_pose_BtoT);
-    // angle_robot_position が　M_PI * 0.9 以上になることを望む
 
-    const auto add_angle = tools::to_radians(60.0);
+    const auto ADD_ANGLE = tools::to_radians(60.0);
+    const auto AIM_ANGLE_THRETHOLD = tools::to_radians(10.0);
+    constexpr auto ROTATION_RADIUS = ROBOT_RADIUS * 2.0;
 
     State new_pose;
-    constexpr auto RADIUS = ROBOT_RADIUS * 2.0;
-    if (std::fabs(angle_robot_position) > M_PI - add_angle) {
+    if (std::fabs(angle_robot_position) > M_PI - AIM_ANGLE_THRETHOLD) {
+      // ボールの裏に回ったら、直進する
       new_pose = trans_BtoT.inverted_transform(-ROBOT_RADIUS, 0.0, 0.0);
     } else {
-      const auto theta = angle_robot_position + std::copysign(add_angle, angle_robot_position);
-      double pos_x = RADIUS * std::cos(theta);
-      double pos_y = RADIUS * std::sin(theta);
+      // ボールの周りを旋回する
+      const auto theta = angle_robot_position + std::copysign(ADD_ANGLE, angle_robot_position);
+      double pos_x = ROTATION_RADIUS * std::cos(theta);
+      double pos_y = ROTATION_RADIUS * std::sin(theta);
       new_pose = trans_BtoT.inverted_transform(pos_x, pos_y, theta + M_PI);
     }
 
-
     data_set.set_parsed_pose(new_pose);
-    // data_set.set_parsed_dribble_power(DRIBBLE_CATCH);
 
-    if (tools::is_same(robot_pose, new_pose, DISTANCE_THRESHOLD, THETA_THRESHOLD)) {
+    // ロボットが目標姿勢に近づき、回転速度が小さくなったら次の行動に移行
+    const auto robot_vel = tools::velocity_state(data_set.get_my_robot());
+    if (tools::is_same(robot_pose, new_pose, DISTANCE_THRESHOLD, THETA_THRESHOLD) &&
+      robot_vel.theta < OMEGA_THRESHOLD) {
       return SHOOT;
     }
 

--- a/consai_robot_controller/src/tactic/shoot_tactics.cpp
+++ b/consai_robot_controller/src/tactic/shoot_tactics.cpp
@@ -92,7 +92,7 @@ ShootTactics::ShootTactics()
     const auto angle_robot_position = tools::calc_angle(State(), robot_pose_BtoT);
 
     const auto ADD_ANGLE = tools::to_radians(60.0);
-    const auto AIM_ANGLE_THRETHOLD = tools::to_radians(10.0);
+    const auto AIM_ANGLE_THRETHOLD = tools::to_radians(15.0);
     constexpr auto ROTATION_RADIUS = ROBOT_RADIUS * 2.0;
 
     State new_pose;
@@ -130,12 +130,12 @@ ShootTactics::ShootTactics()
 
     if (data_set.is_pass()) {
       const auto distance = tools::distance(ball_pose, target_pose);
-      const double ALPHA = 1.0;
+      const double ALPHA = 1.3;
       shoot_speed = std::clamp(distance * ALPHA, MIN_SHOOT_SPEED, MAX_SHOOT_SPEED);
     }
 
     data_set.set_parsed_dribble_power(DRIBBLE_RELEASE);
-    data_set.set_parsed_kick_power(MAX_SHOOT_SPEED);
+    data_set.set_parsed_kick_power(shoot_speed);
 
     if (tools::distance(robot_pose, ball_pose) > ROBOT_RADIUS * 2.0) {
       return WAIT;

--- a/consai_tools/include/consai_tools/geometry_tools.hpp
+++ b/consai_tools/include/consai_tools/geometry_tools.hpp
@@ -34,6 +34,7 @@ double normalize_theta(const double theta);
 double distance(const State & pose1, const State & pose2);
 State pose_state(const TrackedRobot & robot);
 State pose_state(const TrackedBall & ball);
+State velocity_state(const TrackedRobot & robot);
 double to_radians(const double degrees);
 double to_degrees(const double radians);
 State intersection(const State & p1, const State & p2, const State & p3, const State & p4);

--- a/consai_tools/src/geometry_tools.cpp
+++ b/consai_tools/src/geometry_tools.cpp
@@ -65,6 +65,19 @@ State pose_state(const TrackedBall & ball)
   return state;
 }
 
+State velocity_state(const TrackedRobot & robot)
+{
+  State state;
+  if (robot.vel.size() > 0) {
+    state.x = robot.vel[0].x;
+    state.y = robot.vel[0].y;
+  }
+  if (robot.vel_angular.size() > 0) {
+    state.theta = robot.vel_angular[0];
+  }
+  return state;
+}
+
 double to_radians(const double degrees)
 {
   constexpr double TO_RADIANS = M_PI / 180.0;

--- a/tests/test_scenario_ball_placement.py
+++ b/tests/test_scenario_ball_placement.py
@@ -55,7 +55,7 @@ def test_far_position(rcst_comm):
 
 
 def test_so_far_position(rcst_comm):
-    init_our_placement(rcst_comm, -6.0, -4.5, ball_x=5.9, ball_y=4.4)
+    init_our_placement(rcst_comm, -5.8, -4.3, ball_x=5.9, ball_y=4.4)
     assert wait_for_placement(rcst_comm) is True
 
 


### PR DESCRIPTION
パスとシュートをshoot_tacticsに実装します

パス威力のリミットを調整したので、
#135 をクローズできます。

#132 に関連して以下の変更が行われます。

- 中間位置に収束したかどうかが毎回発生することで遅い気がする　：　改善されます
- タイガースがやっているクルッと回って蹴るやつやりたい　：　実装しました
- ボール取るときに右肩タックルする　：　おそらく改善します。実機検証が必要です
- ボールをなかなか蹴らない　：　おそらく改善します。実機検証が必要です。
- 衝突回避により、相手 or 味方がボール持っているときに取れない　：　改善します。
- 完全にフリーな状態のボールを取りに行くときにも謎の回避動作がはいってしまう　：　改善します。
- ボールアプローチがあまりにも遅い　：　おそらく改善します。実機検証が必要です

## その他修正

Attackerの行動をmove_to_poseからmove_on_lineに変更しています。

下記の記述をすると、目標角度が強制的に0度になるためです。

```python
move_to_ball = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
```