### PR TITLE
Update setplay motion.

### DIFF
--- a/consai_examples/consai_examples/decisions/attacker.py
+++ b/consai_examples/consai_examples/decisions/attacker.py
@@ -210,7 +210,8 @@ def gen_chase_ball_function():
 
 def gen_setplay_shoot_function():
     def function(self, robot_id):
-        move_to_ball = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
+        move_to_ball = Operation().move_on_line(
+            TargetXY.ball(), TargetXY.our_robot(robot_id), 0.05, TargetTheta.look_ball())
         setplay_shoot = move_to_ball.with_shooting_for_setplay_to(TargetXY.their_goal())
         self._operator.operate(robot_id, setplay_shoot)
     return function

--- a/consai_robot_controller/include/consai_robot_controller/tactic/shoot_tactics.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/tactic/shoot_tactics.hpp
@@ -43,7 +43,7 @@ public:
   ~ShootTactics() = default;
   bool update(
     const State & shoot_target, const TrackedRobot & my_robot, const TrackedBall & ball,
-    const bool & is_pass,
+    const bool & is_pass, const bool & is_setplay,
     State & parsed_pose, double & parsed_kick_power, double & parsed_dribble_power);
 
 private:

--- a/consai_robot_controller/include/consai_robot_controller/tactic/tactic_data_set.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/tactic/tactic_data_set.hpp
@@ -54,6 +54,7 @@ public:
     parsed_dribble_power_ = parsed_dribble_power;
   }
   void set_pass(const bool & is_pass) {is_pass_ = is_pass;}
+  void set_setplay(const bool & is_setplay) {is_setplay_ = is_setplay;}
 
   TrackedRobot get_my_robot(void) {return my_robot_;}
   TrackedBall get_ball(void) {return ball_;}
@@ -62,6 +63,7 @@ public:
   double get_parsed_kick_power(void) {return parsed_kick_power_;}
   double get_parsed_dribble_power(void) {return parsed_dribble_power_;}
   bool is_pass(void) {return is_pass_;}
+  bool is_setplay(void) {return is_setplay_;}
 
 private:
   TrackedRobot my_robot_;
@@ -71,6 +73,7 @@ private:
   double parsed_kick_power_;
   double parsed_dribble_power_;
   bool is_pass_ = false;
+  bool is_setplay_ = false;
 };
 
 }  // namespace tactics

--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -108,16 +108,8 @@ bool FieldInfoParser::parse_goal(
   }
 
   if (goal->kick_enable && has_kick_target) {
-    if (goal->kick_setplay) {
-      if (tactic_control_ball_->kick_ball_at_setplay(
-          kick_target, my_robot, ball, goal->kick_pass, parsed_pose, kick_power, dribble_power))
-      {
-        return true;
-      }
-    }
-
     shoot_tactics_.update(
-      kick_target, my_robot, ball, goal->kick_pass, parsed_pose, kick_power,
+      kick_target, my_robot, ball, goal->kick_pass, goal->kick_setplay, parsed_pose, kick_power,
       dribble_power);
     return true;
   }

--- a/consai_robot_controller/src/tactic/shoot_tactics.cpp
+++ b/consai_robot_controller/src/tactic/shoot_tactics.cpp
@@ -91,7 +91,12 @@ ShootTactics::ShootTactics()
 
       const auto ADD_ANGLE = tools::to_radians(60.0);
       const auto AIM_ANGLE_THRETHOLD = tools::to_radians(15.0);
-      constexpr auto ROTATION_RADIUS = ROBOT_RADIUS * 2.0;
+
+      // セットプレイ時は回転半径を大きくする
+      double rotation_radius = ROBOT_RADIUS * 2.0;
+      if (data_set.is_setplay()) {
+        rotation_radius = ROBOT_RADIUS * 4.0;
+      }
 
       State new_pose;
       if (std::fabs(angle_robot_position) > M_PI - AIM_ANGLE_THRETHOLD) {
@@ -100,8 +105,8 @@ ShootTactics::ShootTactics()
       } else {
         // ボールの周りを旋回する
         const auto theta = angle_robot_position + std::copysign(ADD_ANGLE, angle_robot_position);
-        double pos_x = ROTATION_RADIUS * std::cos(theta);
-        double pos_y = ROTATION_RADIUS * std::sin(theta);
+        double pos_x = rotation_radius * std::cos(theta);
+        double pos_y = rotation_radius * std::sin(theta);
         new_pose = trans_BtoT.inverted_transform(pos_x, pos_y, theta + M_PI);
       }
 
@@ -146,7 +151,7 @@ ShootTactics::ShootTactics()
 
 bool ShootTactics::update(
   const State & shoot_target, const TrackedRobot & my_robot, const TrackedBall & ball,
-  const bool & is_pass,
+  const bool & is_pass, const bool & is_setplay,
   State & parsed_pose, double & parsed_kick_power, double & parsed_dribble_power)
 {
   const auto robot_id = my_robot.robot_id.id;
@@ -166,6 +171,7 @@ bool ShootTactics::update(
   TacticDataSet data_set(my_robot, ball, shoot_target, parsed_pose, parsed_kick_power,
     parsed_dribble_power);
   data_set.set_pass(is_pass);
+  data_set.set_setplay(is_setplay);
   const auto next_tactic = tactic_functions_[tactic_name_[robot_id]](data_set);
 
   if (tactic_name_[robot_id] != next_tactic) {

--- a/tests/test_scenario_ball_placement.py
+++ b/tests/test_scenario_ball_placement.py
@@ -50,7 +50,7 @@ def test_near_position(rcst_comm):
 
 
 def test_far_position(rcst_comm):
-    init_our_placement(rcst_comm, 6.0, 4.5)
+    init_our_placement(rcst_comm, 5.8, 4.3)
     assert wait_for_placement(rcst_comm) is True
 
 


### PR DESCRIPTION
shoot_tactics にセットプレイのフラグを追加します。

セットプレイ時は、ボール周りを旋回するときの半径を広くします。

これにより、ボールプレースメント後にボールへ衝突する問題を解決します。

Close #162 

また、セットプレイ時の遠くからボールへ向かうときの目標角度が0度になっていたので、ボールを向くように修正します。