### PR TITLE
setplay時のアタッカー動作追加

### DIFF
--- a/consai_examples/consai_examples/decisions/attacker.py
+++ b/consai_examples/consai_examples/decisions/attacker.py
@@ -104,6 +104,35 @@ class AttackerDecision(DecisionBase):
             move_to_ball = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
             setplay_shoot = move_to_ball.with_shooting_for_setplay_to(TargetXY.their_goal())
             self._operator.operate(robot_id, setplay_shoot)
+    
+    def our_direct(self, robot_id):
+        move_to_ball = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
+        move_to_ball.with_ball_receiving()
+        move_to_ball = move_to_ball.with_reflecting_to(TargetXY.their_goal())
+
+        # パス可能なIDのリストを取得
+        receivers_id_list = self._field_observer.pass_shoot().search_receivers_list(robot_id)
+        # パスできる味方ロボットがいる場合はパスする
+        if len(receivers_id_list) > 0:
+            passing = move_to_ball.with_passing_to(TargetXY.our_robot(receivers_id_list[0]))
+            self._operator.operate(robot_id, passing)
+            return
+        
+        # シュート可能なIDリストを取得
+        shoot_pos_list = self._field_observer.pass_shoot().get_shoot_pos_list()
+        # シュートできる場合はシュートする
+        if len(shoot_pos_list) > 0:
+            shooting = move_to_ball.with_shooting_to(
+                TargetXY.value(shoot_pos_list[0].x, shoot_pos_list[0].y))
+            self._operator.operate(robot_id, shooting)
+            return
+        
+        # パスとシュートができない場合はゴール中央に向けてシュートする
+        goal_pos_list = self._field_observer.pass_shoot().get_goal_pos_list()
+        shooting_center = move_to_ball.with_shooting_to(
+            TargetXY.value(goal_pos_list[0].x, goal_pos_list[0].y))
+        self._operator.operate(robot_id, shooting_center)
+        return
 
     def their_direct(self, robot_id):
         prevent_direct_shooting = Operation().move_on_line(
@@ -222,7 +251,7 @@ def gen_their_penalty_function():
 for name in ['our_pre_kickoff', 'their_pre_kickoff', 'their_kickoff', 'our_pre_penalty']:
     setattr(AttackerDecision, name, gen_chase_ball_function())
 
-for name in ['our_kickoff', 'our_penalty', 'our_direct', 'our_indirect']:
+for name in ['our_kickoff', 'our_penalty', 'our_indirect']:
     setattr(AttackerDecision, name, gen_setplay_shoot_function())
 
 for name in ['their_pre_penalty', 'their_penalty', 'their_penalty_inplay']:

--- a/consai_examples/consai_examples/decisions/attacker.py
+++ b/consai_examples/consai_examples/decisions/attacker.py
@@ -104,7 +104,7 @@ class AttackerDecision(DecisionBase):
             move_to_ball = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
             setplay_shoot = move_to_ball.with_shooting_for_setplay_to(TargetXY.their_goal())
             self._operator.operate(robot_id, setplay_shoot)
-    
+
     def our_direct(self, robot_id):
         move_to_ball = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
         move_to_ball.with_ball_receiving()
@@ -117,7 +117,7 @@ class AttackerDecision(DecisionBase):
             passing = move_to_ball.with_passing_to(TargetXY.our_robot(receivers_id_list[0]))
             self._operator.operate(robot_id, passing)
             return
-        
+
         # シュート可能なIDリストを取得
         shoot_pos_list = self._field_observer.pass_shoot().get_shoot_pos_list()
         # シュートできる場合はシュートする
@@ -126,7 +126,7 @@ class AttackerDecision(DecisionBase):
                 TargetXY.value(shoot_pos_list[0].x, shoot_pos_list[0].y))
             self._operator.operate(robot_id, shooting)
             return
-        
+
         # パスとシュートができない場合はゴール中央に向けてシュートする
         goal_pos_list = self._field_observer.pass_shoot().get_goal_pos_list()
         shooting_center = move_to_ball.with_shooting_to(

--- a/consai_examples/consai_examples/decisions/attacker.py
+++ b/consai_examples/consai_examples/decisions/attacker.py
@@ -110,14 +110,6 @@ class AttackerDecision(DecisionBase):
         move_to_ball.with_ball_receiving()
         move_to_ball = move_to_ball.with_reflecting_to(TargetXY.their_goal())
 
-        # パス可能なIDのリストを取得
-        receivers_id_list = self._field_observer.pass_shoot().search_receivers_list(robot_id)
-        # パスできる味方ロボットがいる場合はパスする
-        if len(receivers_id_list) > 0:
-            passing = move_to_ball.with_passing_to(TargetXY.our_robot(receivers_id_list[0]))
-            self._operator.operate(robot_id, passing)
-            return
-
         # シュート可能なIDリストを取得
         shoot_pos_list = self._field_observer.pass_shoot().get_shoot_pos_list()
         # シュートできる場合はシュートする
@@ -127,10 +119,17 @@ class AttackerDecision(DecisionBase):
             self._operator.operate(robot_id, shooting)
             return
 
+        # パス可能なIDのリストを取得
+        receivers_id_list = self._field_observer.pass_shoot().search_receivers_list(robot_id)
+        # パスできる味方ロボットがいる場合はパスする
+        if len(receivers_id_list) > 0:
+            passing = move_to_ball.with_passing_to(TargetXY.our_robot(receivers_id_list[0]))
+            self._operator.operate(robot_id, passing)
+            return
+
         # パスとシュートができない場合はゴール中央に向けてシュートする
-        goal_pos_list = self._field_observer.pass_shoot().get_goal_pos_list()
         shooting_center = move_to_ball.with_shooting_to(
-            TargetXY.value(goal_pos_list[0].x, goal_pos_list[0].y))
+            TargetXY.their_goal())
         self._operator.operate(robot_id, shooting_center)
         return
 

--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -56,7 +56,7 @@ def enable_update_attacker_by_ball_pos():
         not referee.their_pre_penalty() and \
         not referee.their_penalty() and \
         not referee.their_ball_placement()
-        # not observer.ball_motion().is_moving() and \
+    # not observer.ball_motion().is_moving() and \
 
 
 def update_decisions(changed_ids: list[int], num_of_zone_roles: int):

--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -50,13 +50,13 @@ def enable_update_attacker_by_ball_pos():
     # ボールが動いてたり、ディフェンスエリアや自ゴール側場外にあるときは役割を更新しない
     return not observer.ball_position().is_in_our_defense_area() and \
         not observer.ball_position().is_outside() and \
-        not observer.ball_motion().is_moving() and \
         not referee.our_ball_placement() and \
         not referee.our_pre_penalty() and \
         not referee.our_penalty() and \
         not referee.their_pre_penalty() and \
         not referee.their_penalty() and \
         not referee.their_ball_placement()
+        # not observer.ball_motion().is_moving() and \
 
 
 def update_decisions(changed_ids: list[int], num_of_zone_roles: int):

--- a/consai_examples/consai_examples/observer/pass_shoot_observer.py
+++ b/consai_examples/consai_examples/observer/pass_shoot_observer.py
@@ -42,6 +42,9 @@ class PassShootObserver:
 
     def get_shoot_pos_list(self) -> list[State2D]:
         return self._present_shoot_pos_list
+    
+    def get_goal_pos_list(self) -> list[State2D]:
+        return self._goal_pos_list
 
     def search_receivers_list(self, my_robot_id: int) -> list[int]:
         # パス可能なロボットIDのリストを返す関数

--- a/consai_examples/consai_examples/observer/pass_shoot_observer.py
+++ b/consai_examples/consai_examples/observer/pass_shoot_observer.py
@@ -42,9 +42,6 @@ class PassShootObserver:
 
     def get_shoot_pos_list(self) -> list[State2D]:
         return self._present_shoot_pos_list
-    
-    def get_goal_pos_list(self) -> list[State2D]:
-        return self._goal_pos_list
 
     def search_receivers_list(self, my_robot_id: int) -> list[int]:
         # パス可能なロボットIDのリストを返す関数


### PR DESCRIPTION
アタッカーの動作にsetplay時の処理を追加しました。
動作順は以下のとおりです。

1. パス可能な味方ロボットにパスする
2. シュート可能な相手ゴールにシュートする
3. 1と2ができないときは相手ゴール中心にシュートする