### PR TITLE
Update role priority

### DIFF
--- a/consai_examples/consai_examples/role_assignment.py
+++ b/consai_examples/consai_examples/role_assignment.py
@@ -64,9 +64,9 @@ class RoleAssignment(Node):
         self._active_role_list = [
             RoleName.GOALIE,
             RoleName.ATTACKER,
+            RoleName.SUB_ATTACKER,
             RoleName.CENTER_BACK1,
             RoleName.CENTER_BACK2,
-            RoleName.SUB_ATTACKER,
             RoleName.ZONE1,
             RoleName.ZONE2,
             RoleName.ZONE3,

--- a/consai_examples/tests/test_role_assignment.py
+++ b/consai_examples/tests/test_role_assignment.py
@@ -122,8 +122,8 @@ def test_ロボットが消えても優先度の高いロールは空けない�
     assert assignor.get_assigned_roles_and_ids() == [
         (RoleName.GOALIE, 0),
         (RoleName.ATTACKER, 3),
-        (RoleName.CENTER_BACK1, 7),
-        (RoleName.CENTER_BACK2, 6)]
+        (RoleName.SUB_ATTACKER, 7),
+        (RoleName.CENTER_BACK1, 6)]
 
 
 def test_ボールに一番近いロボットがAttackerになること(rclpy_init_shutdown):
@@ -141,8 +141,8 @@ def test_ボールに一番近いロボットがAttackerになること(rclpy_in
 
     assert assignor.get_assigned_roles_and_ids() == [
         (RoleName.ATTACKER, 9),
-        (RoleName.CENTER_BACK1, 8),
-        (RoleName.CENTER_BACK2, 7)]
+        (RoleName.SUB_ATTACKER, 8),
+        (RoleName.CENTER_BACK1, 7)]
 
 
 def test_goalieが一番ボールに近いときは二番目に近いロボットがAttackerになること(rclpy_init_shutdown):
@@ -161,7 +161,7 @@ def test_goalieが一番ボールに近いときは二番目に近いロボッ�
     assert assignor.get_assigned_roles_and_ids() == [
         (RoleName.GOALIE, 9),
         (RoleName.ATTACKER, 8),
-        (RoleName.CENTER_BACK1, 7)]
+        (RoleName.SUB_ATTACKER, 7)]
 
 
 def test_ボール位置によってAttackerを更新しないフラグが適用されること(rclpy_init_shutdown):
@@ -179,8 +179,8 @@ def test_ボール位置によってAttackerを更新しないフラグが適用
 
     assert assignor.get_assigned_roles_and_ids() == [
         (RoleName.ATTACKER, 7),
-        (RoleName.CENTER_BACK1, 8),
-        (RoleName.CENTER_BACK2, 9)]
+        (RoleName.SUB_ATTACKER, 8),
+        (RoleName.CENTER_BACK1, 9)]
 
 
 @pytest.mark.parametrize("robot_num, expected_indexes",


### PR DESCRIPTION
sub_attackerの優先度を3番目にします。

これにより、ロボット台数が減ってもボールプレースメントが実行可能になります。

ただし、ディフェンスの台数が減ってしまいます。

Close #165