### PR TITLE
Switch ball system model of KF when ball is far from robots.

### DIFF
--- a/consai_tools/include/consai_tools/geometry_tools.hpp
+++ b/consai_tools/include/consai_tools/geometry_tools.hpp
@@ -41,6 +41,8 @@ State intersection(const State & p1, const State & p2, const State & p3, const S
 bool is_same(
   const State & p1, const State & p2,
   const double distance_threshold = 0.01, const double theta_threshold = 0.17);
+bool is_visible(const TrackedRobot & robot, const double threshold = 0.01);
+bool is_visible(const TrackedBall & ball, const double threshold = 0.01);
 
 class Trans
 {

--- a/consai_tools/src/geometry_tools.cpp
+++ b/consai_tools/src/geometry_tools.cpp
@@ -125,6 +125,22 @@ bool is_same(
   return false;
 }
 
+bool is_visible(const TrackedRobot & robot, const double threshold)
+{
+  if (robot.visibility.size() > 0) {
+    return robot.visibility[0] > threshold;
+  }
+  return false;
+}
+
+bool is_visible(const TrackedBall & ball, const double threshold)
+{
+  if (ball.visibility.size() > 0) {
+    return ball.visibility[0] > threshold;
+  }
+  return false;
+}
+
 Trans::Trans(const State & center, const double theta)
 {
   center_ = std::complex<double>(center.x, center.y);

--- a/consai_vision_tracker/CMakeLists.txt
+++ b/consai_vision_tracker/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(consai_msgs REQUIRED)
+find_package(consai_tools REQUIRED)
 find_package(consai_visualizer_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
@@ -40,6 +41,7 @@ target_compile_definitions(tracker_component
   PRIVATE "CONSAI_VISION_TRACKER_BUILDING_DLL")
 ament_target_dependencies(tracker_component
   consai_msgs
+  consai_tools
   consai_visualizer_msgs
   rclcpp
   rclcpp_components

--- a/consai_vision_tracker/include/consai_vision_tracker/ball_tracker.hpp
+++ b/consai_vision_tracker/include/consai_vision_tracker/ball_tracker.hpp
@@ -61,6 +61,8 @@ private:
   std::shared_ptr<MeasurementModelGaussianUncertainty> meas_model_;
   std::shared_ptr<Gaussian> prior_;
   std::shared_ptr<ExtendedKalmanFilter> filter_;
+
+  int outlier_count_ = 0;
 };
 
 }  // namespace consai_vision_tracker

--- a/consai_vision_tracker/include/consai_vision_tracker/ball_tracker.hpp
+++ b/consai_vision_tracker/include/consai_vision_tracker/ball_tracker.hpp
@@ -43,7 +43,8 @@ public:
   explicit BallTracker(const double dt = 0.01);
 
   void push_back_observation(const DetectionBall & ball);
-  TrackedBall update();
+  TrackedBall update(const bool use_uncertain_sys_model);
+  TrackedBall prev_estimation(void) const {return prev_tracked_ball_;}
 
 private:
   void reset_prior();
@@ -52,8 +53,10 @@ private:
   std::vector<TrackedBall> ball_observations_;
   TrackedBall prev_tracked_ball_;
 
-  std::shared_ptr<ConditionalGaussian> sys_pdf_;
-  std::shared_ptr<SystemModelGaussianUncertainty> sys_model_;
+  std::shared_ptr<ConditionalGaussian> sys_uncertain_pdf_;
+  std::shared_ptr<SystemModelGaussianUncertainty> sys_uncertain_model_;
+  std::shared_ptr<ConditionalGaussian> sys_certain_pdf_;
+  std::shared_ptr<SystemModelGaussianUncertainty> sys_certain_model_;
   std::shared_ptr<ConditionalGaussian> meas_pdf_;
   std::shared_ptr<MeasurementModelGaussianUncertainty> meas_model_;
   std::shared_ptr<Gaussian> prior_;

--- a/consai_vision_tracker/include/consai_vision_tracker/robot_tracker.hpp
+++ b/consai_vision_tracker/include/consai_vision_tracker/robot_tracker.hpp
@@ -47,6 +47,7 @@ public:
   void push_back_observation(const DetectionRobot & robot);
   TrackedRobot update();
   RobotLocalVelocity calc_local_velocity();
+  TrackedRobot prev_estimation(void) const {return prev_tracked_robot_;}
 
 private:
   void reset_prior();

--- a/consai_vision_tracker/package.xml
+++ b/consai_vision_tracker/package.xml
@@ -11,6 +11,7 @@
 
   <depend>launch_ros</depend>
   <depend>consai_msgs</depend>
+  <depend>consai_tools</depend>
   <depend>consai_visualizer_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/consai_vision_tracker/src/ball_tracker.cpp
+++ b/consai_vision_tracker/src/ball_tracker.cpp
@@ -141,11 +141,20 @@ void BallTracker::push_back_observation(const DetectionBall & ball)
 
 TrackedBall BallTracker::update(const bool use_uncertain_sys_model)
 {
+  constexpr auto OUTLIER_COUNT_THRESHOLD = 10;
+
   // 観測値から外れ値を取り除く
   for (auto it = ball_observations_.begin(); it != ball_observations_.end(); ) {
     if (is_outlier(*it)) {
+      // 外れ値が連続できたら、観測値をそのまま使用する（誘拐対応）
+      outlier_count_++;
+      if (outlier_count_ > OUTLIER_COUNT_THRESHOLD) {
+        std::cout <<"outlier counts out" << std::endl;
+        break;
+      }
       it = ball_observations_.erase(it);
     } else {
+      outlier_count_ = 0;
       ++it;
     }
   }

--- a/consai_vision_tracker/src/ball_tracker.cpp
+++ b/consai_vision_tracker/src/ball_tracker.cpp
@@ -149,7 +149,6 @@ TrackedBall BallTracker::update(const bool use_uncertain_sys_model)
       // 外れ値が連続できたら、観測値をそのまま使用する（誘拐対応）
       outlier_count_++;
       if (outlier_count_ > OUTLIER_COUNT_THRESHOLD) {
-        std::cout <<"outlier counts out" << std::endl;
         break;
       }
       it = ball_observations_.erase(it);


### PR DESCRIPTION
ボールのカルマンフィルタについての変更です。

ボールがロボット近傍にあるかどうかで、システムモデルの不確かさを切り替えます。

これにより、キックされたボールの軌道がより直線に近づきます。

ロボット付近にボールがあるときは不確かさが大きいので、
ボールを蹴った直後にボール予測位置が消失するという問題を避けられます。

Close #220 