### PR TITLE
ロボットのカルマンフィルタに誘拐対策を実装。シナリオテストでできるだけ全ロボットを使用する。

### DIFF
--- a/consai_vision_tracker/include/consai_vision_tracker/robot_tracker.hpp
+++ b/consai_vision_tracker/include/consai_vision_tracker/robot_tracker.hpp
@@ -65,6 +65,8 @@ private:
   std::shared_ptr<MeasurementModelGaussianUncertainty> meas_model_;
   std::shared_ptr<Gaussian> prior_;
   std::shared_ptr<ExtendedKalmanFilter> filter_;
+
+  int outlier_count_ = 0;
 };
 
 }  // namespace consai_vision_tracker

--- a/consai_vision_tracker/src/robot_tracker.cpp
+++ b/consai_vision_tracker/src/robot_tracker.cpp
@@ -158,11 +158,19 @@ void RobotTracker::push_back_observation(const DetectionRobot & robot)
 
 TrackedRobot RobotTracker::update()
 {
+  constexpr auto OUTLIER_COUNT_THRESHOLD = 10;
+
   // 観測値から外れ値を取り除く
   for (auto it = robot_observations_.begin(); it != robot_observations_.end(); ) {
     if (is_outlier(*it)) {
+      // 外れ値が連続できたら、観測値をそのまま使用する（誘拐対応）
+      outlier_count_++;
+      if (outlier_count_ > OUTLIER_COUNT_THRESHOLD) {
+        break;
+      }
       it = robot_observations_.erase(it);
     } else {
+      outlier_count_ = 0;
       ++it;
     }
   }

--- a/tests/test_scenario_ball_placement.py
+++ b/tests/test_scenario_ball_placement.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import time
-import pytest
 
 
 def init_our_placement(rcst_comm, target_x: float, target_y: float,
@@ -24,7 +23,6 @@ def init_our_placement(rcst_comm, target_x: float, target_y: float,
 
     for i in range(num_of_robots):
         rcst_comm.send_blue_robot(i, -1.0, 3.0 - 0.5*i, 0.0)
-    time.sleep(3)  # Wait for the robots to be placed.
 
     rcst_comm.observer.ball_placement().set_targets(
         target_x, target_y, for_blue_team=True)

--- a/tests/test_scenario_force_start.py
+++ b/tests/test_scenario_force_start.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import math
-import time
 
 from rcst.communication import Communication
 
@@ -21,8 +20,9 @@ from rcst.communication import Communication
 def test_shoot_at_force_start(rcst_comm: Communication):
     rcst_comm.send_empty_world()
     rcst_comm.send_ball(0, 0)
+    for i in range(11):
+        rcst_comm.send_blue_robot(i, -3.0, 3.0 - 0.5*i, 0.0)
     rcst_comm.send_blue_robot(2, -0.5, 0.0, math.radians(0))
-    time.sleep(3)  # Wait for the robots to be placed.
 
     rcst_comm.observer.reset()
     rcst_comm.change_referee_command('STOP', 3.0)

--- a/tests/test_scenario_free_kick.py
+++ b/tests/test_scenario_free_kick.py
@@ -21,6 +21,8 @@ from rcst.communication import Communication
 def test_our_free_kick(rcst_comm: Communication):
     rcst_comm.send_empty_world()
     rcst_comm.send_ball(0, 0)
+    for i in range(11):
+        rcst_comm.send_blue_robot(i, -3.0, 3.0 - 0.5*i, 0.0)
     rcst_comm.send_blue_robot(1, -0.5, 0.0, math.radians(0))
 
     rcst_comm.observer.reset()
@@ -33,6 +35,8 @@ def test_our_free_kick(rcst_comm: Communication):
 def test_their_free_kick(rcst_comm: Communication):
     rcst_comm.send_empty_world()
     rcst_comm.send_ball(0, 0)
+    for i in range(11):
+        rcst_comm.send_blue_robot(i, -3.0, 3.0 - 0.5*i, 0.0)
     rcst_comm.send_blue_robot(0, -5.5, 0.0, math.radians(0))
     rcst_comm.send_yellow_robot(0, 0.1, 0.0, math.radians(180))
 

--- a/tests/test_scenario_kickoff.py
+++ b/tests/test_scenario_kickoff.py
@@ -21,6 +21,8 @@ from rcst.communication import Communication
 def test_our_kickoff(rcst_comm: Communication):
     rcst_comm.send_empty_world()
     rcst_comm.send_ball(0, 0)
+    for i in range(11):
+        rcst_comm.send_blue_robot(i, -3.0, 3.0 - 0.5*i, 0.0)
     rcst_comm.send_blue_robot(1, -0.5, 0.0, math.radians(0))
 
     rcst_comm.observer.reset()
@@ -31,10 +33,29 @@ def test_our_kickoff(rcst_comm: Communication):
     assert rcst_comm.observer.goal().ball_has_been_in_positive_goal() is True
 
 
-def test_their_kickoff(rcst_comm: Communication):
+def test_their_kickoff_only_goalie(rcst_comm: Communication):
     rcst_comm.send_empty_world()
     rcst_comm.send_ball(0, 0)
     rcst_comm.send_blue_robot(0, -5.5, 0.0, math.radians(0))
+    rcst_comm.send_yellow_robot(0, 0.1, 0.0, math.radians(180))
+
+    rcst_comm.observer.reset()
+    rcst_comm.change_referee_command('STOP', 3.0)
+    rcst_comm.change_referee_command('PREPARE_KICKOFF_YELLOW', 3.0)
+    rcst_comm.change_referee_command('NORMAL_START', 1.0)
+
+    # Shoot to our goal.
+    rcst_comm.send_ball(0, 0, -6.0, 0.5)
+    time.sleep(5)
+
+    assert rcst_comm.observer.goal().ball_has_been_in_negative_goal() is False
+
+
+def test_their_kickoff_all_robots(rcst_comm: Communication):
+    rcst_comm.send_empty_world()
+    rcst_comm.send_ball(0, 0)
+    for i in range(11):
+        rcst_comm.send_blue_robot(i, -3.0, 3.0 - 0.5*i, 0.0)
     rcst_comm.send_yellow_robot(0, 0.1, 0.0, math.radians(180))
 
     rcst_comm.observer.reset()

--- a/tests/test_scenario_penalty.py
+++ b/tests/test_scenario_penalty.py
@@ -55,44 +55,40 @@ def test_their_penalty_defend(rcst_comm: Communication):
     assert rcst_comm.observer.goal().ball_has_been_in_negative_goal() is False
 
 
-# def blue_robot_are_behind_ball(
-#         ball: Ball, blue_robots: RobotDict, yellow_robots: RobotDict) -> bool:
-#     DISTANCE = 1.0  # meters
-#     KICKER_ID = 1
+def test_robots_be_behind_ball(rcst_comm: Communication):
+    rcst_comm.send_empty_world()
+    for i in range(11):
+        rcst_comm.send_blue_robot(i, -1.0, 3.0 - i * 0.5, math.radians(0))
 
-#     for robot in blue_robots.values():
-#         if robot.id == KICKER_ID:
-#             continue
+    # Kicker robot.
+    rcst_comm.send_blue_robot(1, -2.2, 0.0, math.radians(0))
+    rcst_comm.send_ball(-2, 0)
 
-#         if robot.x > ball.x - DISTANCE:
-#             return False
+    rcst_comm.change_referee_command('STOP', 1.0)
+    rcst_comm.change_referee_command('PREPARE_PENALTY_BLUE', 0.0)
 
-#     return True
+    def blue_robot_are_behind_ball(
+            ball: Ball, blue_robots: RobotDict, yellow_robots: RobotDict) -> bool:
+        DISTANCE = 1.0  # meters
+        KICKER_ID = 1
 
-# TODO: Fix the issue: https://github.com/SSL-Roots/consai_ros2/issues/185
-# def test_robots_be_behind_ball(rcst_comm: Communication):
-#     rcst_comm.send_empty_world()
-#     for i in range(11):
-#         rcst_comm.send_blue_robot(i, -1.0, 3.0 - i * 0.5, math.radians(0))
-#     time.sleep(3)  # Wait for the robots to be placed.
+        for robot in blue_robots.values():
+            if robot.id == KICKER_ID:
+                continue
+            if robot.x > ball.x - DISTANCE:
+                return False
+        return True
 
-#     # Kicker robot.
-#     rcst_comm.send_blue_robot(1, -2.2, 0.0, math.radians(0))
-#     rcst_comm.send_ball(-2, 0)
+    rcst_comm.observer.customized().register_sticky_true_callback(
+        "test", blue_robot_are_behind_ball)
 
-#     rcst_comm.change_referee_command('STOP', 3.0)
-#     rcst_comm.change_referee_command('PREPARE_PENALTY_BLUE', 0.0)
-
-#     rcst_comm.observer.customized().register_sticky_true_callback(
-#         "test", blue_robot_are_behind_ball)
-
-#     success = False
-#     for _ in range(10):
-#         if rcst_comm.observer.customized().get_result("test"):
-#             success = True
-#             break
-#         time.sleep(1)
-#     assert success is True
+    success = False
+    for _ in range(10):
+        if rcst_comm.observer.customized().get_result("test"):
+            success = True
+            break
+        time.sleep(1)
+    assert success is True
 
 
 def test_robots_be_behind_ball_for_their_penalty(rcst_comm: Communication):

--- a/tests/test_scenario_stop.py
+++ b/tests/test_scenario_stop.py
@@ -23,7 +23,8 @@ from rcst.robot import RobotDict
 
 def test_robot_speed(rcst_comm: Communication):
     rcst_comm.send_empty_world()
-    rcst_comm.send_ball(1, 0)
+    ball_x = 1.0
+    rcst_comm.send_ball(ball_x, 0)
     for i in range(11):
         rcst_comm.send_blue_robot(i, -1.0, 3.0 - i * 0.5, math.radians(0))
 
@@ -31,7 +32,7 @@ def test_robot_speed(rcst_comm: Communication):
 
     rcst_comm.observer.reset()
     success = True
-    rcst_comm.send_ball(0, 0, 5.0, 0.0)  # Move the ball
+    rcst_comm.send_ball(ball_x, 0, 5.0, 0.0)  # Move the ball
     for _ in range(5):
         if rcst_comm.observer.robot_speed().some_blue_robots_over(1.5):
             success = False
@@ -40,20 +41,17 @@ def test_robot_speed(rcst_comm: Communication):
     assert success is True
 
 
-def blue_robot_did_not_avoid_ball(
-        ball: Ball, blue_robots: RobotDict, yellow_robots: RobotDict) -> bool:
-    for robot in blue_robots.values():
-        if calc.distance_robot_and_ball(robot, ball) < 0.4:
-            return True
-
-    return False
-
-
 def test_avoid_ball(rcst_comm: Communication):
     rcst_comm.send_empty_world()
     for i in range(11):
         rcst_comm.send_blue_robot(i, -1.0, 3.0 - i * 0.5, math.radians(0))
-    time.sleep(3)  # Wait for the robots to be placed.
+
+    def blue_robot_did_not_avoid_ball(
+            ball: Ball, blue_robots: RobotDict, yellow_robots: RobotDict) -> bool:
+        for robot in blue_robots.values():
+            if calc.distance_robot_and_ball(robot, ball) < 0.4:
+                return True
+        return False
 
     rcst_comm.observer.customized().register_sticky_true_callback(
         "blue_robot_did_not_avoid_ball", blue_robot_did_not_avoid_ball)

--- a/tests/yellow_invert/test_scenario_yellow_invert_kickoff.py
+++ b/tests/yellow_invert/test_scenario_yellow_invert_kickoff.py
@@ -21,6 +21,8 @@ from rcst.communication import Communication
 def test_yellow_invert_our_kickoff(rcst_comm: Communication):
     rcst_comm.send_empty_world()
     rcst_comm.send_ball(0, 0)
+    for i in range(11):
+        rcst_comm.send_yellow_robot(i, 3.0, 3.0 - 0.5*i, 0.0)
     rcst_comm.send_yellow_robot(1, 0.5, 0.0, math.radians(180))
 
     rcst_comm.observer.reset()
@@ -34,6 +36,8 @@ def test_yellow_invert_our_kickoff(rcst_comm: Communication):
 def test_their_kickoff(rcst_comm: Communication):
     rcst_comm.send_empty_world()
     rcst_comm.send_ball(0, 0)
+    for i in range(11):
+        rcst_comm.send_yellow_robot(i, 3.0, 3.0 - 0.5*i, 0.0)
     rcst_comm.send_yellow_robot(0, 5.5, 0.0, math.radians(180))
     rcst_comm.send_blue_robot(0, -0.1, 0.0, math.radians(0))
 


### PR DESCRIPTION
#224 で実施した誘拐対策をロボットにも適用します。

これにより、誘拐後の収束時間が短くなります。

また、シナリオテストでロボット配置後のsleep時間が不要になるため、
全シナリオテストからsleepを極力除去します。

また、できるだけ多くのロボットをシナリオテストで動かします。