### PR TITLE
Sideback追加

### DIFF
--- a/consai_examples/CMakeLists.txt
+++ b/consai_examples/CMakeLists.txt
@@ -34,6 +34,7 @@ install(PROGRAMS
     ${PROJECT_NAME}/decisions/center_back2.py
     ${PROJECT_NAME}/decisions/decision_base.py
     ${PROJECT_NAME}/decisions/goalie.py
+    ${PROJECT_NAME}/decisions/side_back.py
     ${PROJECT_NAME}/decisions/sub_attacker.py
     ${PROJECT_NAME}/decisions/substitute.py
     ${PROJECT_NAME}/decisions/zone_defense.py
@@ -44,6 +45,7 @@ install(PROGRAMS
     ${PROJECT_NAME}/observer/detection_wrapper.py
     ${PROJECT_NAME}/observer/pass_shoot_observer.py
     ${PROJECT_NAME}/observer/pos_vel.py
+    ${PROJECT_NAME}/observer/side_back_target_observer.py
     ${PROJECT_NAME}/observer/zone_ball_observer.py
     ${PROJECT_NAME}/observer/zone_target_observer.py
     ${PROJECT_NAME}/operation_test/ball_boy_test.py

--- a/consai_examples/consai_examples/decisions/decision_base.py
+++ b/consai_examples/consai_examples/decisions/decision_base.py
@@ -25,6 +25,7 @@ class DecisionBase(object):
         self._operator = robot_operator
         self._field_observer = field_observer
         self._num_of_center_back_roles = 0
+        self._num_of_side_back_roles = 0
         self._num_of_zone_roles = 0
         self._PENALTY_WAIT_X = 4.1  # ペナルティキック待機位置のX座標
 
@@ -42,6 +43,9 @@ class DecisionBase(object):
 
     def set_num_of_center_back_roles(self, num_of_center_back_roles):
         self._num_of_center_back_roles = num_of_center_back_roles
+
+    def set_num_of_side_back_roles(self, num_of_side_back_roles):
+        self._num_of_side_back_roles = num_of_side_back_roles
 
     def set_num_of_zone_roles(self, num_of_zone_roles):
         self._num_of_zone_roles = num_of_zone_roles

--- a/consai_examples/consai_examples/decisions/side_back.py
+++ b/consai_examples/consai_examples/decisions/side_back.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# coding: UTF-8
+
+# Copyright 2023 Roots
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from enum import Enum
+
+from decisions.decision_base import DecisionBase
+from operation import Operation
+from operation import TargetXY
+from operation import TargetTheta
+
+
+class SideBackID(Enum):
+    SIDE1 = 0
+    SIDE2 = 1
+
+
+class SideBackDecision(DecisionBase):
+
+    def __init__(self, robot_operator, field_observer, side_id: SideBackID):
+        super().__init__(robot_operator, field_observer)
+        self._side_id = side_id
+        self._our_penalty_pos_x = -self._PENALTY_WAIT_X
+        self._our_penalty_pos_y = 4.5 - 0.3 * (3.0 + self._side_id.value)
+        self._their_penalty_pos_x = self._PENALTY_WAIT_X
+        self._their_penalty_pos_y = 4.5 - 0.3 * (3.0 + self._side_id.value)
+        self._ball_placement_pos_x = -6.0 + 2.0
+        self._ball_placement_pos_y = 1.8 - 0.3 * (8.0 + self._side_id.value)
+
+    def _side_back_operation(self, without_mark=False):
+        SIDE_ID = self._side_id.value
+
+        # FIXME: ボールが相手側にある場合は攻めに役立ちそうなポジションに移動してほしい
+
+        # DFエリア横に相手ロボットがいる、ボールとロボットの間に移動する
+        if self._field_observer.side_back_target().has_target(SIDE_ID) and without_mark is False:
+            target_id = self._field_observer.side_back_target().get_target_id(SIDE_ID)
+            operation = Operation().move_on_line(
+                TargetXY.their_robot(target_id), TargetXY.ball(),
+                distance_from_p1=0.5, target_theta=TargetTheta.look_ball())
+            operation = operation.with_ball_receiving()
+        else:
+            # DFエリア横付近で待機する
+            target_x, target_y = self._get_side_target_xy()
+            operation = Operation().move_to_pose(
+                TargetXY.value(target_x, target_y), TargetTheta.look_ball())
+            operation = operation.with_reflecting_to(TargetXY.their_goal())
+        return operation
+
+    def _get_side_target_xy(self):
+        # 待機場所をそれぞれの関数で算出する
+        target_x = -3.5
+        target_y = 0
+        if self._side_id == SideBackID.SIDE1:
+            return self._get_side1_target_xy()
+        elif self._side_id == SideBackID.SIDE2:
+            return self._get_side2_target_xy()
+        return target_x, target_y
+
+    def _get_side1_target_xy(self):
+        target_x = -3.5
+        target_y = 3.0
+        return target_x, target_y
+
+    def _get_side2_target_xy(self):
+        target_x = -3.5
+        target_y = -3.0
+        return target_x, target_y
+
+    def stop(self, robot_id):
+        operation = self._side_back_operation(without_mark=True)
+        operation = operation.enable_avoid_ball()
+        operation = operation.enable_avoid_pushing_robots()
+        self._operator.operate(robot_id, operation)
+
+    def inplay(self, robot_id):
+        operation = self._side_back_operation()
+        self._operator.operate(robot_id, operation)
+
+    def our_pre_kickoff(self, robot_id):
+        operation = self._side_back_operation(without_mark=True)
+        operation = operation.enable_avoid_ball()
+        self._operator.operate(robot_id, operation)
+
+    def our_kickoff(self, robot_id):
+        operation = self._side_back_operation(without_mark=True)
+        self._operator.operate(robot_id, operation)
+
+    def their_pre_kickoff(self, robot_id):
+        operation = self._side_back_operation(without_mark=True)
+        operation = operation.enable_avoid_ball()
+        self._operator.operate(robot_id, operation)
+
+    def their_kickoff(self, robot_id):
+        operation = self._side_back_operation(without_mark=True)
+        self._operator.operate(robot_id, operation)
+
+    def our_direct(self, robot_id):
+        operation = self._side_back_operation()
+        operation = operation.enable_avoid_ball()
+        self._operator.operate(robot_id, operation)
+
+    def their_direct(self, robot_id):
+        operation = self._side_back_operation()
+        operation = operation.enable_avoid_ball()
+        self._operator.operate(robot_id, operation)
+
+    def our_indirect(self, robot_id):
+        operation = self._side_back_operation()
+        operation = operation.enable_avoid_ball()
+        self._operator.operate(robot_id, operation)
+
+    def their_indirect(self, robot_id):
+        operation = self._side_back_operation()
+        operation = operation.enable_avoid_ball()
+        self._operator.operate(robot_id, operation)
+
+    def _our_penalty_operation(self):
+        return Operation().move_to_pose(
+            TargetXY.value(self._our_penalty_pos_x, self._our_penalty_pos_y),
+            TargetTheta.look_ball())
+
+    def _their_penalty_operation(self):
+        return Operation().move_to_pose(
+            TargetXY.value(self._their_penalty_pos_x, self._their_penalty_pos_y),
+            TargetTheta.look_ball())
+
+    def _ball_placement_operation(self):
+        return Operation().move_to_pose(
+            TargetXY.value(
+                self._ball_placement_pos_x, self._ball_placement_pos_y),
+            TargetTheta.look_ball())
+
+
+def gen_our_penalty_function():
+    def function(self, robot_id):
+        operation = self._our_penalty_operation()
+        operation = operation.enable_avoid_ball()
+        self._operator.operate(robot_id, operation)
+    return function
+
+
+def gen_their_penalty_function():
+    def function(self, robot_id):
+        operation = self._their_penalty_operation()
+        operation = operation.enable_avoid_ball()
+        self._operator.operate(robot_id, operation)
+    return function
+
+
+def gen_ball_placement_function():
+    def function(self, robot_id, placement_pos=None):
+        operation = self._ball_placement_operation()
+        operation = operation.enable_avoid_placement_area(placement_pos)
+        operation = operation.enable_avoid_pushing_robots()
+        self._operator.operate(robot_id, operation)
+    return function
+
+
+for name in ['our_pre_penalty', 'our_penalty', 'our_penalty_inplay']:
+    setattr(SideBackDecision, name, gen_our_penalty_function())
+
+for name in ['their_pre_penalty', 'their_penalty', 'their_penalty_inplay']:
+    setattr(SideBackDecision, name, gen_their_penalty_function())
+
+for name in ['our_ball_placement', 'their_ball_placement']:
+    setattr(SideBackDecision, name, gen_ball_placement_function())

--- a/consai_examples/consai_examples/decisions/side_back.py
+++ b/consai_examples/consai_examples/decisions/side_back.py
@@ -34,6 +34,7 @@ class SideBackDecision(DecisionBase):
     def __init__(self, robot_operator, field_observer, side_id: SideBackID):
         super().__init__(robot_operator, field_observer)
         self._side_id = side_id
+        self._distance_from = 0.25
         self._our_penalty_pos_x = -self._PENALTY_WAIT_X
         self._our_penalty_pos_y = 4.5 - 0.3 * (3.0 + self._side_id.value)
         self._their_penalty_pos_x = self._PENALTY_WAIT_X
@@ -51,7 +52,7 @@ class SideBackDecision(DecisionBase):
             target_id = self._field_observer.side_back_target().get_target_id(SIDE_ID)
             operation = Operation().move_on_line(
                 TargetXY.their_robot(target_id), TargetXY.ball(),
-                distance_from_p1=0.5, target_theta=TargetTheta.look_ball())
+                distance_from_p1=self._distance_from, target_theta=TargetTheta.look_ball())
             operation = operation.with_ball_receiving()
         else:
             # DFエリア横付近で待機する

--- a/consai_examples/consai_examples/field_observer.py
+++ b/consai_examples/consai_examples/field_observer.py
@@ -22,6 +22,7 @@ from consai_examples.observer.detection_wrapper import DetectionWrapper
 from consai_examples.observer.ball_position_observer import BallPositionObserver
 from consai_examples.observer.ball_placement_observer import BallPlacementObserver
 from consai_examples.observer.zone_ball_observer import ZoneBallObserver
+from consai_examples.observer.side_back_target_observer import SideBackTargetObserver
 from consai_examples.observer.zone_target_observer import ZoneTargetObserver
 from consai_examples.observer.ball_motion_observer import BallMotionObserver
 from consai_examples.observer.pass_shoot_observer import PassShootObserver
@@ -45,6 +46,7 @@ class FieldObserver(Node):
         self._ball_placement_observer = BallPlacementObserver()
         self._zone_ball_observer = ZoneBallObserver()
         self._zone_target_observer = ZoneTargetObserver()
+        self._side_back_target_observer = SideBackTargetObserver()
         self._ball_motion_observer = BallMotionObserver()
         self._pass_shoot_observer = PassShootObserver()
 
@@ -64,6 +66,9 @@ class FieldObserver(Node):
 
     def zone_target(self) -> ZoneTargetObserver:
         return self._zone_target_observer
+
+    def side_back_target(self) -> SideBackTargetObserver:
+        return self._side_back_target_observer
 
     def ball_motion(self) -> BallMotionObserver:
         return self._ball_motion_observer
@@ -94,6 +99,7 @@ class FieldObserver(Node):
             self.ball_position().is_in_our_side())
         self._zone_target_observer.update(
             self._detection_wrapper.their_robots(), self._num_of_zone_roles)
+        self._side_back_target_observer.update(self._detection_wrapper.their_robots())
         self._ball_motion_observer.update(self._detection_wrapper.ball())
         self._pass_shoot_observer.update(
             self._detection_wrapper.ball(),

--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -23,6 +23,7 @@ import rclpy
 from decisions.attacker import AttackerDecision
 from decisions.center_back import CenterBackDecision, CenterBackID
 from decisions.goalie import GoaleDecision
+from decisions.side_back import SideBackDecision, SideBackID
 from decisions.side_wing import SideWingDecision, WingID
 from decisions.sub_attacker import SubAttackerDecision
 from decisions.substitute import SubstituteDecision
@@ -224,6 +225,8 @@ if __name__ == '__main__':
         RoleName.ZONE4: ZoneDefenseDecision(operator, observer, ZoneDefenseID.ZONE4),
         RoleName.LEFT_WING: SideWingDecision(operator, observer, WingID.LEFT),
         RoleName.RIGHT_WING: SideWingDecision(operator, observer, WingID.RIGHT),
+        RoleName.SIDE_BACK1: SideBackDecision(operator, observer, SideBackID.SIDE1),
+        RoleName.SIDE_BACK2: SideBackDecision(operator, observer, SideBackID.SIDE2),
         RoleName.SUBSTITUTE: SubstituteDecision(operator, observer, args.invert),
     }
 

--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -42,6 +42,14 @@ def num_of_active_center_back_roles(active_roles):
     return len(set(role_zone_list) & set(active_roles))
 
 
+def num_of_active_side_back_roles(active_roles):
+    # アクティブなサイドバック担当者の数を返す
+    role_zone_list = [
+        RoleName.SIDE_BACK1,
+        RoleName.SIDE_BACK2]
+    return len(set(role_zone_list) & set(active_roles))
+
+
 def num_of_active_zone_roles(active_roles):
     # アクティブなゾーンディフェンス担当者の数を返す
     role_zone_list = [
@@ -68,6 +76,7 @@ def enable_update_attacker_by_ball_pos():
 
 def update_decisions(changed_ids: list[int],
                      num_of_center_back_roles: int,
+                     num_of_side_back_roles: int,
                      num_of_zone_roles: int):
     for role, robot_id in assignor.get_assigned_roles_and_ids():
         # 役割が変わったロボットのみ、行動を更新する
@@ -76,6 +85,8 @@ def update_decisions(changed_ids: list[int],
 
         # センターバックの担当者数をセットする
         decisions[role].set_num_of_center_back_roles(num_of_center_back_roles)
+        # サイドバックの担当者数をセットする
+        decisions[role].set_num_of_side_back_roles(num_of_side_back_roles)
         # ゾーンディフェンスの担当者数をセットする
         decisions[role].set_num_of_zone_roles(num_of_zone_roles)
 
@@ -153,10 +164,12 @@ def main():
         # 担当者がいるroleの中から、ゾーンディフェンスの数を抽出する
         assigned_roles = [t[0] for t in assignor.get_assigned_roles_and_ids()]
         num_of_center_back_roles = num_of_active_center_back_roles(assigned_roles)
+        num_of_side_back_roles = num_of_active_side_back_roles(assigned_roles)
         num_of_zone_roles = num_of_active_zone_roles(assigned_roles)
         observer.set_num_of_zone_roles(num_of_zone_roles)
 
-        update_decisions(changed_ids, num_of_center_back_roles, num_of_zone_roles)
+        update_decisions(changed_ids, num_of_center_back_roles,
+                         num_of_side_back_roles, num_of_zone_roles)
 
         elapsed_time = time.time() - start_time
         if elapsed_time < TARGET_PERIOD:

--- a/consai_examples/consai_examples/observer/side_back_target_observer.py
+++ b/consai_examples/consai_examples/observer/side_back_target_observer.py
@@ -23,8 +23,8 @@ class SideBackTargetObserver():
     def __init__(self):
         # 0が上側、1が下側
         self._side_back_targets: dict[int, int] = {0: None, 1: None}
-        # ロボット半径 x 2 + α
-        self._DEFENSE_AREA_MARGIN = 0.6
+        # FIXME: 要調整、ディフェンスエリア侵入が多いようなら大きくする
+        self._DEFENSE_AREA_MARGIN = 0.1
         self._penalty_corner_upper_front = Field.penalty_pose('our', 'upper_front')
         self._penalty_corner_lower_front = Field.penalty_pose('our', 'lower_front')
 

--- a/consai_examples/consai_examples/observer/side_back_target_observer.py
+++ b/consai_examples/consai_examples/observer/side_back_target_observer.py
@@ -21,19 +21,20 @@ import math
 class SideBackTargetObserver():
 
     def __init__(self):
+        # 0が上側、1が下側
         self._side_back_targets: dict[int, int] = {0: None, 1: None}
         # ロボット半径 x 2 + α
         self._DEFENSE_AREA_MARGIN = 0.6
         self._penalty_corner_upper_front = Field.penalty_pose('our', 'upper_front')
         self._penalty_corner_lower_front = Field.penalty_pose('our', 'lower_front')
 
-    def has_zone_target(self, zone_id: int) -> bool:
-        return self._side_back_targets[zone_id] is not None
+    def has_target(self, side_id: int) -> bool:
+        return self._side_back_targets[side_id] is not None
 
-    def get_zone_target_id(self, zone_id: int) -> int:
-        return self._side_back_targets[zone_id]
+    def get_target_id(self, side_id: int) -> int:
+        return self._side_back_targets[side_id]
 
-    def update(self, their_robots: dict[int, PosVel], num_of_zone_roles: int) -> None:
+    def update(self, their_robots: dict[int, PosVel]) -> None:
         # ディフェンスエリア横にいる相手ロボットを検出する
         # 存在しない場合はNoneをセットする
         self._reset_targets()

--- a/consai_examples/consai_examples/observer/side_back_target_observer.py
+++ b/consai_examples/consai_examples/observer/side_back_target_observer.py
@@ -1,0 +1,91 @@
+# Copyright 2024 Roots
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from consai_examples.observer.pos_vel import PosVel
+from consai_msgs.msg import State2D
+from field import Field
+import math
+
+
+class SideBackTargetObserver():
+
+    def __init__(self):
+        self._side_back_targets: dict[int, int] = {0: None, 1: None}
+        # ロボット半径 x 2 + α
+        self._DEFENSE_AREA_MARGIN = 0.6
+        self._penalty_corner_upper_front = Field.penalty_pose('our', 'upper_front')
+        self._penalty_corner_lower_front = Field.penalty_pose('our', 'lower_front')
+
+    def has_zone_target(self, zone_id: int) -> bool:
+        return self._side_back_targets[zone_id] is not None
+
+    def get_zone_target_id(self, zone_id: int) -> int:
+        return self._side_back_targets[zone_id]
+
+    def update(self, their_robots: dict[int, PosVel], num_of_zone_roles: int) -> None:
+        # ディフェンスエリア横にいる相手ロボットを検出する
+        # 存在しない場合はNoneをセットする
+        self._reset_targets()
+
+        self._update_targets(their_robots)
+
+    def _update_targets(self, their_robots: dict[int, PosVel]) -> None:
+        # ターゲットを抽出する
+        nearest_x0 = 10.0
+        nearest_x1 = 10.0
+        nearest_id0 = None
+        nearest_id1 = None
+        for robot_id, robot in their_robots.items():
+            if self._is_in_top_side(robot.pos()):
+                if robot.pos().x < nearest_x0:
+                    nearest_x0 = robot.pos().x
+                    nearest_id0 = robot_id
+                continue
+
+            if self._is_in_bottom_side(robot.pos()):
+                if robot.pos().x < nearest_x1:
+                    nearest_x1 = robot.pos().x
+                    nearest_id1 = robot_id
+                continue
+
+        self._side_back_targets[0] = nearest_id0
+        self._side_back_targets[1] = nearest_id1
+
+    def _reset_targets(self) -> None:
+        # ターゲットを初期化する
+        self._side_back_targets = {0: None, 1: None}
+
+    def _is_in_defence_area(self, pos: State2D) -> bool:
+        # ディフェンスエリアに入ってたらtrue
+        defense_x = self._penalty_corner_upper_front.x + self._DEFENSE_AREA_MARGIN
+        defense_y = self._penalty_corner_upper_front.y + self._DEFENSE_AREA_MARGIN
+        if pos.x < defense_x and math.fabs(pos.y) < defense_y:
+            return True
+        return False
+
+    def _is_in_top_side(self, pos: State2D) -> bool:
+        # ディフェンスエリアの横（上側）にロボットがいればtrue
+        if self._is_in_defence_area(pos):
+            return False
+        if pos.x < self._penalty_corner_upper_front.x and pos.y > self._penalty_corner_upper_front.y:
+            return True
+        return False
+
+    def _is_in_bottom_side(self, pos: State2D) -> bool:
+        # ディフェンスエリアの横（下側）にロボットがいればtrue
+        if self._is_in_defence_area(pos):
+            return False
+        if pos.x < self._penalty_corner_lower_front.x and pos.y < self._penalty_corner_lower_front.y:
+            return True
+        return False

--- a/consai_examples/consai_examples/observer/side_back_target_observer.py
+++ b/consai_examples/consai_examples/observer/side_back_target_observer.py
@@ -79,7 +79,8 @@ class SideBackTargetObserver():
         # ディフェンスエリアの横（上側）にロボットがいればtrue
         if self._is_in_defence_area(pos):
             return False
-        if pos.x < self._penalty_corner_upper_front.x and pos.y > self._penalty_corner_upper_front.y:
+        if pos.x < self._penalty_corner_upper_front.x and \
+                pos.y > self._penalty_corner_upper_front.y:
             return True
         return False
 
@@ -87,6 +88,7 @@ class SideBackTargetObserver():
         # ディフェンスエリアの横（下側）にロボットがいればtrue
         if self._is_in_defence_area(pos):
             return False
-        if pos.x < self._penalty_corner_lower_front.x and pos.y < self._penalty_corner_lower_front.y:
+        if pos.x < self._penalty_corner_lower_front.x and \
+                pos.y < self._penalty_corner_lower_front.y:
             return True
         return False

--- a/consai_examples/consai_examples/role_assignment.py
+++ b/consai_examples/consai_examples/role_assignment.py
@@ -69,12 +69,14 @@ class RoleAssignment(Node):
             RoleName.SUB_ATTACKER,
             RoleName.CENTER_BACK1,
             RoleName.CENTER_BACK2,
+            RoleName.SIDE_BACK1,
+            RoleName.SIDE_BACK2,
             RoleName.ZONE1,
             RoleName.ZONE2,
             RoleName.ZONE3,
             RoleName.ZONE4,
-            RoleName.LEFT_WING,
-            RoleName.RIGHT_WING,
+            # RoleName.LEFT_WING,
+            # RoleName.RIGHT_WING,
         ]
         # 実際に運用するroleのリスト
         # イエローカードや交代指示などで役割が変更されます

--- a/consai_examples/consai_examples/role_assignment.py
+++ b/consai_examples/consai_examples/role_assignment.py
@@ -39,7 +39,9 @@ class RoleName(Enum):
     ZONE4 = 8
     LEFT_WING = 11
     RIGHT_WING = 12
-    SUBSTITUTE = 13
+    SIDE_BACK1 = 13
+    SIDE_BACK2 = 14
+    SUBSTITUTE = 15
 
 
 # フィールド状況を見て、ロボットの役割を決めるノード


### PR DESCRIPTION
ディフェンスエリアの横をまもります。  
ディフェンスエリアの横に相手ロボットがいたら、そいつをマンマークします。  
それ以外はてきとうな位置で待機します。  
サイドウィングたちをリストラしています。  

いまゾーンディフェンスと動きがかぶっている部分がありますが、それはゾーン側を直すべきなので一旦無視してください。  
マンマーク対象が被る問題があります。