### PR TITLE
シュート関連のパラメータ更新

### DIFF
--- a/consai_examples/consai_examples/decisions/attacker.py
+++ b/consai_examples/consai_examples/decisions/attacker.py
@@ -97,7 +97,8 @@ class AttackerDecision(DecisionBase):
         receivers_id_list = self._field_observer.pass_shoot().search_receivers_list(robot_id)
         # パスできる味方ロボットがいる場合はパスする
         if len(receivers_id_list) > 0:
-            passing = move_to_ball.with_passing_for_setplay_to(TargetXY.our_robot(receivers_id_list[0]))
+            passing = move_to_ball.with_passing_for_setplay_to(
+                TargetXY.our_robot(receivers_id_list[0]))
             self._operator.operate(robot_id, passing)
             return
 

--- a/consai_examples/consai_examples/decisions/attacker.py
+++ b/consai_examples/consai_examples/decisions/attacker.py
@@ -166,7 +166,7 @@ class AttackerDecision(DecisionBase):
             kick_pos = self._kick_pos_to_reflect_on_wall(placement_pos)
             move_to_ball = Operation().move_on_line(
                 TargetXY.ball(), TargetXY.our_robot(robot_id), 0.5, TargetTheta.look_ball())
-            put_ball_back = move_to_ball.with_shooting_to(
+            put_ball_back = move_to_ball.with_shooting_for_setplay_to(
                 TargetXY.value(kick_pos.x, kick_pos.y))
             self._operator.operate(robot_id, put_ball_back)
             return
@@ -175,7 +175,7 @@ class AttackerDecision(DecisionBase):
             # ボール位置が配置目標位置から離れているときはパスする
             move_to_ball = Operation().move_on_line(
                 TargetXY.ball(), TargetXY.our_robot(robot_id), 0.5, TargetTheta.look_ball())
-            passing = move_to_ball.with_passing_to(TargetXY.value(
+            passing = move_to_ball.with_passing_for_setplay_to(TargetXY.value(
                 placement_pos.x, placement_pos.y))
             self._operator.operate(robot_id, passing)
             return

--- a/consai_examples/consai_examples/decisions/attacker.py
+++ b/consai_examples/consai_examples/decisions/attacker.py
@@ -88,7 +88,7 @@ class AttackerDecision(DecisionBase):
         shoot_pos_list = self._field_observer.pass_shoot().get_shoot_pos_list()
         # シュートできる場合はシュートする
         if len(shoot_pos_list) > 0:
-            shooting = move_to_ball.with_shooting_to(
+            shooting = move_to_ball.with_shooting_for_setplay_to(
                 TargetXY.value(shoot_pos_list[0].x, shoot_pos_list[0].y))
             self._operator.operate(robot_id, shooting)
             return
@@ -97,12 +97,12 @@ class AttackerDecision(DecisionBase):
         receivers_id_list = self._field_observer.pass_shoot().search_receivers_list(robot_id)
         # パスできる味方ロボットがいる場合はパスする
         if len(receivers_id_list) > 0:
-            passing = move_to_ball.with_passing_to(TargetXY.our_robot(receivers_id_list[0]))
+            passing = move_to_ball.with_passing_for_setplay_to(TargetXY.our_robot(receivers_id_list[0]))
             self._operator.operate(robot_id, passing)
             return
 
         # パスとシュートができない場合はゴール中央に向けてシュートする
-        shooting_center = move_to_ball.with_shooting_to(
+        shooting_center = move_to_ball.with_shooting_for_setplay_to(
             TargetXY.their_goal())
         self._operator.operate(robot_id, shooting_center)
         return

--- a/consai_examples/consai_examples/operation.py
+++ b/consai_examples/consai_examples/operation.py
@@ -287,6 +287,14 @@ class Operation():
         goal.kick_target = target_xy.constraint
         return Operation(goal)
 
+    def with_passing_for_setplay_to(self, target_xy: TargetXY) -> 'Operation':
+        goal = deepcopy(self._goal)
+        goal.kick_enable = True
+        goal.kick_pass = True
+        goal.kick_setplay = True
+        goal.kick_target = target_xy.constraint
+        return Operation(goal)
+
     def with_dribbling_to(self, target_xy: TargetXY) -> 'Operation':
         goal = deepcopy(self._goal)
         goal.dribble_enable = True

--- a/consai_robot_controller/include/consai_robot_controller/tactic/shoot_tactics.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/tactic/shoot_tactics.hpp
@@ -50,6 +50,7 @@ private:
   std::map<RobotID, TacticName> tactic_name_;
   std::map<RobotID, Time> tactic_time_;
   std::map<TacticName, std::function<TacticName(TacticDataSet & data_set)>> tactic_functions_;
+  State shoot_target_;
 };
 
 }  // namespace shoot_tactics

--- a/consai_robot_controller/src/tactic/shoot_tactics.cpp
+++ b/consai_robot_controller/src/tactic/shoot_tactics.cpp
@@ -94,7 +94,7 @@ ShootTactics::ShootTactics()
       const auto robot_pose_BtoT = trans_BtoT.transform(robot_pose);
       const auto angle_robot_position = tools::calc_angle(State(), robot_pose_BtoT);
 
-      const auto ADD_ANGLE = tools::to_radians(25.0);
+      const auto ADD_ANGLE = tools::to_radians(45.0);
       const auto AIM_ANGLE_THRETHOLD = tools::to_radians(45.0);
       const auto AIM_ANGLE_THRETHOLD_FOR_SETPLAY = tools::to_radians(10.0);
 

--- a/consai_robot_controller/src/tactic/shoot_tactics.cpp
+++ b/consai_robot_controller/src/tactic/shoot_tactics.cpp
@@ -30,6 +30,7 @@ static constexpr double MAX_SHOOT_SPEED = 5.5;  // m/s
 static constexpr double MIN_SHOOT_SPEED = 2.0;  // m/s
 static constexpr double WAIT_DISTANCE = 0.7;  // meters
 static constexpr double ROTATE_RADIUS = ROBOT_RADIUS * 2.0;  // meters
+static constexpr double BALL_RADIUS = 0.0215;  // meters
 static constexpr auto WAIT = "WAIT";
 static constexpr auto APPROACH = "APPROACH";
 static constexpr auto ROTATE = "ROTATE";
@@ -80,7 +81,8 @@ ShootTactics::ShootTactics()
       // 目的位置をしっかり狙ったら、次の行動に移行する
       constexpr auto DISTANCE_THRESHOLD = 0.05;  // meters
       const auto THETA_THRESHOLD = tools::to_radians(5.0);
-      const auto OMEGA_THRESHOLD = 0.1;  // rad/s
+      const auto OMEGA_THRESHOLD = 0.5;  // rad/s
+      const auto OMEGA_THRESHOLD_FOR_SETPLAY = 0.01;  // rad/s
 
       const auto robot_pose = tools::pose_state(data_set.get_my_robot());
       const auto ball_pose = tools::pose_state(data_set.get_ball());
@@ -93,18 +95,25 @@ ShootTactics::ShootTactics()
       const auto angle_robot_position = tools::calc_angle(State(), robot_pose_BtoT);
 
       const auto ADD_ANGLE = tools::to_radians(25.0);
-      const auto AIM_ANGLE_THRETHOLD = tools::to_radians(10.0);
+      const auto AIM_ANGLE_THRETHOLD = tools::to_radians(45.0);
+      const auto AIM_ANGLE_THRETHOLD_FOR_SETPLAY = tools::to_radians(10.0);
 
       // セットプレイ時は回転半径を大きくする
       double rotation_radius = ROTATE_RADIUS;
+      double forward_distance = ROBOT_RADIUS;
+      double aim_angle_threshold = AIM_ANGLE_THRETHOLD;
+      double omega_threshold = OMEGA_THRESHOLD;
       if (data_set.is_setplay()) {
         rotation_radius = ROBOT_RADIUS * 4.0;
+        forward_distance = ROBOT_RADIUS * 2.0;
+        aim_angle_threshold = AIM_ANGLE_THRETHOLD_FOR_SETPLAY;
+        omega_threshold = OMEGA_THRESHOLD_FOR_SETPLAY;
       }
 
       State new_pose;
-      if (std::fabs(angle_robot_position) + ADD_ANGLE > M_PI - AIM_ANGLE_THRETHOLD) {
+      if (std::fabs(angle_robot_position) + ADD_ANGLE > M_PI - aim_angle_threshold) {
         // ボールの裏に回ったら、直進する
-        new_pose = trans_BtoT.inverted_transform(-ROBOT_RADIUS, 0.0, 0.0);
+        new_pose = trans_BtoT.inverted_transform(-forward_distance, 0.0, 0.0);
       } else {
         // ボールの周りを旋回する
         const auto theta = angle_robot_position + std::copysign(ADD_ANGLE, angle_robot_position);
@@ -116,11 +125,15 @@ ShootTactics::ShootTactics()
       data_set.set_parsed_pose(new_pose);
       data_set.set_parsed_dribble_power(DRIBBLE_CATCH);
 
+
       // ロボットが目標姿勢に近づき、回転速度が小さくなったら次の行動に移行
       const auto robot_vel = tools::velocity_state(data_set.get_my_robot());
+
       if (tools::is_same(robot_pose, new_pose, DISTANCE_THRESHOLD, THETA_THRESHOLD) &&
-        std::fabs(robot_vel.theta) < OMEGA_THRESHOLD)
+        std::fabs(robot_vel.theta) < omega_threshold)
       {
+        // ロボットの移動がぶれないように、目標位置を固定する
+        shoot_target_ = target_pose;
         return SHOOT;
       }
 
@@ -132,14 +145,13 @@ ShootTactics::ShootTactics()
       // ボールが離れたら終了する
       const auto robot_pose = tools::pose_state(data_set.get_my_robot());
       const auto ball_pose = tools::pose_state(data_set.get_ball());
-      const auto target_pose = data_set.get_target();
 
-      const tools::Trans trans_BtoT(ball_pose, tools::calc_angle(ball_pose, target_pose));
-      const auto new_pose = trans_BtoT.inverted_transform(-ROBOT_RADIUS, 0.0, 0.0);
+      const tools::Trans trans_BtoT(ball_pose, tools::calc_angle(ball_pose, shoot_target_));
+      const auto new_pose = trans_BtoT.inverted_transform(-(ROBOT_RADIUS + BALL_RADIUS), 0.0, 0.0);
 
       double shoot_speed = MAX_SHOOT_SPEED;
       if (data_set.is_pass()) {
-        const auto distance = tools::distance(ball_pose, target_pose);
+        const auto distance = tools::distance(ball_pose, shoot_target_);
         const double ALPHA = 1.3;
         shoot_speed = std::clamp(distance * ALPHA, MIN_SHOOT_SPEED, MAX_SHOOT_SPEED);
       }
@@ -148,7 +160,7 @@ ShootTactics::ShootTactics()
       data_set.set_parsed_dribble_power(DRIBBLE_CATCH);
       data_set.set_parsed_kick_power(shoot_speed);
 
-      if (tools::distance(robot_pose, ball_pose) > ROTATE_RADIUS) {
+      if (tools::distance(robot_pose, ball_pose) > ROTATE_RADIUS * 2.0) {
         return WAIT;
       }
 


### PR DESCRIPTION

下記の変更を実施します

- Attackerのour directでセットプレイキックを使う
- ボール周りで旋回するときの速度を変更
- ROTATEからSHOOTに遷移するときにキック目標位置を固定する
  - 直進走行がブレることを防ぎます

Close #229