### PR TITLE
ゾーンマンマークを追加

### DIFF
--- a/consai_examples/CMakeLists.txt
+++ b/consai_examples/CMakeLists.txt
@@ -46,6 +46,7 @@ install(PROGRAMS
     ${PROJECT_NAME}/observer/pos_vel.py
     ${PROJECT_NAME}/observer/side_back_target_observer.py
     ${PROJECT_NAME}/observer/zone_ball_observer.py
+    ${PROJECT_NAME}/observer/zone_man_mark_target_observer.py
     ${PROJECT_NAME}/observer/zone_target_observer.py
     ${PROJECT_NAME}/operation_test/ball_boy_test.py
     ${PROJECT_NAME}/operation_test/control.py

--- a/consai_examples/consai_examples/decisions/zone_defense.py
+++ b/consai_examples/consai_examples/decisions/zone_defense.py
@@ -37,6 +37,7 @@ class ZoneDefenseDecision(DecisionBase):
     def __init__(self, robot_operator, field_observer, zone_id: ZoneDefenseID):
         super().__init__(robot_operator, field_observer)
         self._zone_id = zone_id
+        self._distance_from = 0.4
         self._our_penalty_pos_x = -self._PENALTY_WAIT_X
         self._our_penalty_pos_y = 4.5 - 0.3 * (6.0 + self._zone_id.value)
         self._their_penalty_pos_x = self._PENALTY_WAIT_X
@@ -54,11 +55,12 @@ class ZoneDefenseDecision(DecisionBase):
         # ball_is_in_my_zone = self._ball_is_in_zone()
 
         # ゾーン内の相手ロボットがいる、ボールとロボットの間に移動する
-        if self._field_observer.zone_target().has_zone_target(ZONE_ID) and without_mark is False:
-            target_id = self._field_observer.zone_target().get_zone_target_id(ZONE_ID)
+        # if self._field_observer.zone_target().has_zone_target(ZONE_ID) and without_mark is False:
+        if self._field_observer.zone_man_mark_target().has_target(ZONE_ID) and without_mark is False:
+            target_id = self._field_observer.zone_man_mark_target().get_target_id(ZONE_ID)
             operation = Operation().move_on_line(
                 TargetXY.their_robot(target_id), TargetXY.ball(),
-                distance_from_p1=0.5, target_theta=TargetTheta.look_ball())
+                distance_from_p1=self._distance_from, target_theta=TargetTheta.look_ball())
             operation = operation.with_ball_receiving()
         else:
             # ゾーン内で待機する

--- a/consai_examples/consai_examples/decisions/zone_defense.py
+++ b/consai_examples/consai_examples/decisions/zone_defense.py
@@ -47,7 +47,7 @@ class ZoneDefenseDecision(DecisionBase):
 
     def _zone_defense_operation(self, robot_id, without_mark=False):
         # ゾーンディフェンスの担当者数に合わせて、待機位置を変更する
-        ZONE_ID = self._zone_id.value
+        # ZONE_ID = self._zone_id.value
         target_id = self._field_observer.man_mark().get_mark_robot_id(robot_id)
 
         # ゾーン内にボールがあるか判定

--- a/consai_examples/consai_examples/decisions/zone_defense.py
+++ b/consai_examples/consai_examples/decisions/zone_defense.py
@@ -56,7 +56,8 @@ class ZoneDefenseDecision(DecisionBase):
 
         # ゾーン内の相手ロボットがいる、ボールとロボットの間に移動する
         # if self._field_observer.zone_target().has_zone_target(ZONE_ID) and without_mark is False:
-        if self._field_observer.zone_man_mark_target().has_target(ZONE_ID) and without_mark is False:
+        if self._field_observer.zone_man_mark_target().has_target(ZONE_ID) and \
+                without_mark is False:
             target_id = self._field_observer.zone_man_mark_target().get_target_id(ZONE_ID)
             operation = Operation().move_on_line(
                 TargetXY.their_robot(target_id), TargetXY.ball(),

--- a/consai_examples/consai_examples/decisions/zone_defense.py
+++ b/consai_examples/consai_examples/decisions/zone_defense.py
@@ -45,9 +45,10 @@ class ZoneDefenseDecision(DecisionBase):
         self._ball_placement_pos_x = -6.0 + 2.0
         self._ball_placement_pos_y = 1.8 - 0.3 * (4.0 + self._zone_id.value)
 
-    def _zone_defense_operation(self, without_mark=False):
+    def _zone_defense_operation(self, robot_id, without_mark=False):
         # ゾーンディフェンスの担当者数に合わせて、待機位置を変更する
         ZONE_ID = self._zone_id.value
+        target_id = self._field_observer.man_mark().get_mark_robot_id(robot_id)
 
         # ゾーン内にボールがあるか判定
         # ボールを追いかける処理は行ってない（アタッカーと取り合いになるため）
@@ -56,9 +57,7 @@ class ZoneDefenseDecision(DecisionBase):
 
         # ゾーン内の相手ロボットがいる、ボールとロボットの間に移動する
         # if self._field_observer.zone_target().has_zone_target(ZONE_ID) and without_mark is False:
-        if self._field_observer.zone_man_mark_target().has_target(ZONE_ID) and \
-                without_mark is False:
-            target_id = self._field_observer.zone_man_mark_target().get_target_id(ZONE_ID)
+        if target_id != -1 and without_mark is False:
             operation = Operation().move_on_line(
                 TargetXY.their_robot(target_id), TargetXY.ball(),
                 distance_from_p1=self._distance_from, target_theta=TargetTheta.look_ball())
@@ -173,50 +172,50 @@ class ZoneDefenseDecision(DecisionBase):
         return False
 
     def stop(self, robot_id):
-        operation = self._zone_defense_operation(without_mark=True)
+        operation = self._zone_defense_operation(robot_id, without_mark=True)
         operation = operation.enable_avoid_ball()
         operation = operation.enable_avoid_pushing_robots()
         self._operator.operate(robot_id, operation)
 
     def inplay(self, robot_id):
-        operation = self._zone_defense_operation()
+        operation = self._zone_defense_operation(robot_id)
         self._operator.operate(robot_id, operation)
 
     def our_pre_kickoff(self, robot_id):
-        operation = self._zone_defense_operation(without_mark=True)
+        operation = self._zone_defense_operation(robot_id, without_mark=True)
         operation = operation.enable_avoid_ball()
         self._operator.operate(robot_id, operation)
 
     def our_kickoff(self, robot_id):
-        operation = self._zone_defense_operation(without_mark=True)
+        operation = self._zone_defense_operation(robot_id, without_mark=True)
         self._operator.operate(robot_id, operation)
 
     def their_pre_kickoff(self, robot_id):
-        operation = self._zone_defense_operation(without_mark=True)
+        operation = self._zone_defense_operation(robot_id, without_mark=True)
         operation = operation.enable_avoid_ball()
         self._operator.operate(robot_id, operation)
 
     def their_kickoff(self, robot_id):
-        operation = self._zone_defense_operation(without_mark=True)
+        operation = self._zone_defense_operation(robot_id, without_mark=True)
         self._operator.operate(robot_id, operation)
 
     def our_direct(self, robot_id):
-        operation = self._zone_defense_operation()
+        operation = self._zone_defense_operation(robot_id)
         operation = operation.enable_avoid_ball()
         self._operator.operate(robot_id, operation)
 
     def their_direct(self, robot_id):
-        operation = self._zone_defense_operation()
+        operation = self._zone_defense_operation(robot_id)
         operation = operation.enable_avoid_ball()
         self._operator.operate(robot_id, operation)
 
     def our_indirect(self, robot_id):
-        operation = self._zone_defense_operation()
+        operation = self._zone_defense_operation(robot_id)
         operation = operation.enable_avoid_ball()
         self._operator.operate(robot_id, operation)
 
     def their_indirect(self, robot_id):
-        operation = self._zone_defense_operation()
+        operation = self._zone_defense_operation(robot_id)
         operation = operation.enable_avoid_ball()
         self._operator.operate(robot_id, operation)
 
@@ -255,7 +254,7 @@ def gen_their_penalty_function():
 
 def gen_ball_placement_function():
     def function(self, robot_id, placement_pos=None):
-        operation = self._zone_defense_operation(without_mark=True)
+        operation = self._zone_defense_operation(robot_id, without_mark=True)
         operation = operation.enable_avoid_ball()
         operation = operation.enable_avoid_placement_area(placement_pos)
         operation = operation.enable_avoid_pushing_robots()

--- a/consai_examples/consai_examples/field_observer.py
+++ b/consai_examples/consai_examples/field_observer.py
@@ -21,8 +21,9 @@ from robocup_ssl_msgs.msg import TrackedFrame
 from consai_examples.observer.detection_wrapper import DetectionWrapper
 from consai_examples.observer.ball_position_observer import BallPositionObserver
 from consai_examples.observer.ball_placement_observer import BallPlacementObserver
-from consai_examples.observer.zone_ball_observer import ZoneBallObserver
 from consai_examples.observer.side_back_target_observer import SideBackTargetObserver
+from consai_examples.observer.zone_ball_observer import ZoneBallObserver
+from consai_examples.observer.zone_man_mark_target_observer import ZoneManMarkTargetObserver
 from consai_examples.observer.zone_target_observer import ZoneTargetObserver
 from consai_examples.observer.ball_motion_observer import BallMotionObserver
 from consai_examples.observer.pass_shoot_observer import PassShootObserver
@@ -47,6 +48,7 @@ class FieldObserver(Node):
         self._zone_ball_observer = ZoneBallObserver()
         self._zone_target_observer = ZoneTargetObserver()
         self._side_back_target_observer = SideBackTargetObserver()
+        self._zone_man_mark_target_observer = ZoneManMarkTargetObserver()
         self._ball_motion_observer = BallMotionObserver()
         self._pass_shoot_observer = PassShootObserver()
 
@@ -69,6 +71,9 @@ class FieldObserver(Node):
 
     def side_back_target(self) -> SideBackTargetObserver:
         return self._side_back_target_observer
+
+    def zone_man_mark_target(self) -> ZoneManMarkTargetObserver:
+        return self._zone_man_mark_target_observer
 
     def ball_motion(self) -> BallMotionObserver:
         return self._ball_motion_observer
@@ -100,6 +105,7 @@ class FieldObserver(Node):
         self._zone_target_observer.update(
             self._detection_wrapper.their_robots(), self._num_of_zone_roles)
         self._side_back_target_observer.update(self._detection_wrapper.their_robots())
+        self._zone_man_mark_target_observer.update(self._detection_wrapper.their_robots())
         self._ball_motion_observer.update(self._detection_wrapper.ball())
         self._pass_shoot_observer.update(
             self._detection_wrapper.ball(),

--- a/consai_examples/consai_examples/observer/man_mark_observer.py
+++ b/consai_examples/consai_examples/observer/man_mark_observer.py
@@ -152,7 +152,9 @@ class ManMarkObserver:
             our_id for our_id in self._mark_dict.keys() if our_id not in our_robots]
         # 実際に削除
         for our_id in to_remove_via_theirs + to_remove_via_ours:
-            self._mark_dict.pop(our_id)
+            # 更新タイミングによってはエラーになるため存在確認
+            if our_id in self._mark_dict:
+                self._mark_dict.pop(our_id)
 
     def _is_marked(self, their_bot_id: TheirIDType) -> bool:
         return their_bot_id in self._mark_dict.values()

--- a/consai_examples/consai_examples/observer/man_mark_observer.py
+++ b/consai_examples/consai_examples/observer/man_mark_observer.py
@@ -17,6 +17,7 @@ from consai_msgs.msg import State2D
 from consai_tools.geometry import geometry_tools as tool
 from consai_visualizer_msgs.msg import Objects
 from consai_visualizer_msgs.msg import ShapeLine
+import copy
 from field import Field
 import math
 
@@ -65,7 +66,8 @@ class ManMarkObserver:
 
     def set_our_active_bot_ids(self, our_active_bot_ids: list[OurIDType]) -> None:
         # アクティブじゃなくなったロボットのマーク情報を削除
-        for fired_bot_id in set(self._our_active_bot_ids) - set(our_active_bot_ids):
+        fired_bot_ids = set(self._our_active_bot_ids) - set(our_active_bot_ids)
+        for fired_bot_id in fired_bot_ids:
             if fired_bot_id in self._mark_dict.keys():
                 self._mark_dict.pop(fired_bot_id)
 
@@ -88,7 +90,10 @@ class ManMarkObserver:
         vis_objects.sub_layer = 'mark'
         vis_objects.z_order = 4
 
-        for our_id, their_id in self._mark_dict.items():
+        # Avoid dict size change during iteration
+        mark_dict = copy.deepcopy(self._mark_dict)
+
+        for our_id, their_id in mark_dict.items():
             if our_id not in our_robots.keys() or their_id not in their_robots.keys():
                 continue
 

--- a/consai_examples/consai_examples/observer/side_back_target_observer.py
+++ b/consai_examples/consai_examples/observer/side_back_target_observer.py
@@ -67,7 +67,7 @@ class SideBackTargetObserver():
         # ターゲットを初期化する
         self._side_back_targets = {0: None, 1: None}
 
-    def _is_in_defence_area(self, pos: State2D) -> bool:
+    def _is_in_defense_area(self, pos: State2D) -> bool:
         # ディフェンスエリアに入ってたらtrue
         defense_x = self._penalty_corner_upper_front.x + self._DEFENSE_AREA_MARGIN
         defense_y = self._penalty_corner_upper_front.y + self._DEFENSE_AREA_MARGIN
@@ -77,7 +77,7 @@ class SideBackTargetObserver():
 
     def _is_in_top_side(self, pos: State2D) -> bool:
         # ディフェンスエリアの横（上側）にロボットがいればtrue
-        if self._is_in_defence_area(pos):
+        if self._is_in_defense_area(pos):
             return False
         if pos.x < self._penalty_corner_upper_front.x and \
                 pos.y > self._penalty_corner_upper_front.y:
@@ -86,7 +86,7 @@ class SideBackTargetObserver():
 
     def _is_in_bottom_side(self, pos: State2D) -> bool:
         # ディフェンスエリアの横（下側）にロボットがいればtrue
-        if self._is_in_defence_area(pos):
+        if self._is_in_defense_area(pos):
             return False
         if pos.x < self._penalty_corner_lower_front.x and \
                 pos.y < self._penalty_corner_lower_front.y:

--- a/consai_examples/consai_examples/observer/zone_man_mark_target_observer.py
+++ b/consai_examples/consai_examples/observer/zone_man_mark_target_observer.py
@@ -70,7 +70,7 @@ class ZoneManMarkTargetObserver():
         # ZONEターゲットを初期化する
         self._zone_man_mark_targets = {0: None, 1: None, 2: None, 3: None}
 
-    def _is_in_defence_area(self, pos: State2D) -> bool:
+    def _is_in_defense_area(self, pos: State2D) -> bool:
         # ディフェンスエリアに入ってたらtrue
         defense_x = self._penalty_corner_upper_front.x + self._DEFENSE_AREA_MARGIN
 

--- a/consai_examples/consai_examples/observer/zone_man_mark_target_observer.py
+++ b/consai_examples/consai_examples/observer/zone_man_mark_target_observer.py
@@ -1,0 +1,82 @@
+# Copyright 2024 Roots
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from consai_examples.observer.pos_vel import PosVel
+from consai_msgs.msg import State2D
+from field import Field
+import math
+
+
+class ZoneManMarkTargetObserver():
+
+    def __init__(self):
+        self._zone_man_mark_targets: dict[int, int] = {0: None, 1: None, 2: None, 3: None}
+        self._max_targets = 4
+
+        # FIXME: 要調整、ディフェンスエリア侵入が多いようなら大きくする
+        self._DEFENSE_AREA_MARGIN = 0.2
+        self._penalty_corner_upper_front = Field.penalty_pose('our', 'upper_front')
+        self._penalty_corner_lower_front = Field.penalty_pose('our', 'lower_front')
+
+    def has_target(self, zone_id: int) -> bool:
+        return self._zone_man_mark_targets[zone_id] is not None
+
+    def get_target_id(self, zone_id: int) -> int:
+        return self._zone_man_mark_targets[zone_id]
+
+    def update(self, their_robots: dict[int, PosVel]) -> None:
+        # ゾーンディフェンス担当者に合わせて、マンマークする相手ロボットを検出する
+        # 存在しない場合はNoneをセットする
+        self._reset_zone_targets()
+
+        self._update_targets(their_robots)
+
+    def _update_targets(self, their_robots: dict[int, PosVel]) -> None:
+        # ZONE1に属するターゲットを抽出する
+        nearest_x = 10.0
+
+        # robot.pos().xの値とIDのタプルのリストを作成
+        robot_x_id_pairs = [(robot.pos().x, robot_id) for robot_id, robot in their_robots.items()]
+
+        # xがある値より小さい場合はそのロボットIDを無視する
+        threshold_x = self._penalty_corner_upper_front.x + self._DEFENSE_AREA_MARGIN
+        filtered_pairs = [(x, robot_id)
+                          for x, robot_id in robot_x_id_pairs if (x < 0 and x > threshold_x)]
+
+        # robot.pos().xの値で昇順ソート
+        sorted_pairs = sorted(filtered_pairs)
+        # ソート済みのロボットIDのリストを取得
+        sorted_robot_ids = [robot_id for x, robot_id in sorted_pairs]
+
+        # 空ではない
+        if sorted_robot_ids:
+            for i, sorted_robot_id in enumerate(sorted_robot_ids):
+                if i >= self._max_targets:
+                    break
+                self._zone_man_mark_targets[i] = sorted_robot_id
+
+    def _reset_zone_targets(self) -> None:
+        # ZONEターゲットを初期化する
+        self._zone_man_mark_targets = {0: None, 1: None, 2: None, 3: None}
+
+    def _is_in_defence_area(self, pos: State2D) -> bool:
+        # ディフェンスエリアに入ってたらtrue
+        defense_x = self._penalty_corner_upper_front.x + self._DEFENSE_AREA_MARGIN
+        defense_y = self._penalty_corner_upper_front.y + self._DEFENSE_AREA_MARGIN
+
+        # ディデンスエリア横はサイドバックが守るので無視
+        # if pos.x < defense_x and math.fabs(pos.y) < defense_y:
+        if pos.x < defense_x:
+            return True
+        return False

--- a/consai_examples/consai_examples/observer/zone_man_mark_target_observer.py
+++ b/consai_examples/consai_examples/observer/zone_man_mark_target_observer.py
@@ -15,7 +15,6 @@
 from consai_examples.observer.pos_vel import PosVel
 from consai_msgs.msg import State2D
 from field import Field
-import math
 
 
 class ZoneManMarkTargetObserver():

--- a/consai_examples/consai_examples/observer/zone_man_mark_target_observer.py
+++ b/consai_examples/consai_examples/observer/zone_man_mark_target_observer.py
@@ -73,10 +73,8 @@ class ZoneManMarkTargetObserver():
     def _is_in_defence_area(self, pos: State2D) -> bool:
         # ディフェンスエリアに入ってたらtrue
         defense_x = self._penalty_corner_upper_front.x + self._DEFENSE_AREA_MARGIN
-        defense_y = self._penalty_corner_upper_front.y + self._DEFENSE_AREA_MARGIN
 
         # ディデンスエリア横はサイドバックが守るので無視
-        # if pos.x < defense_x and math.fabs(pos.y) < defense_y:
         if pos.x < defense_x:
             return True
         return False

--- a/consai_examples/consai_examples/observer/zone_man_mark_target_observer.py
+++ b/consai_examples/consai_examples/observer/zone_man_mark_target_observer.py
@@ -43,9 +43,6 @@ class ZoneManMarkTargetObserver():
         self._update_targets(their_robots)
 
     def _update_targets(self, their_robots: dict[int, PosVel]) -> None:
-        # ZONE1に属するターゲットを抽出する
-        nearest_x = 10.0
-
         # robot.pos().xの値とIDのタプルのリストを作成
         robot_x_id_pairs = [(robot.pos().x, robot_id) for robot_id, robot in their_robots.items()]
 

--- a/consai_examples/consai_examples/observer/zone_target_observer.py
+++ b/consai_examples/consai_examples/observer/zone_target_observer.py
@@ -151,7 +151,7 @@ class ZoneTargetObserver():
         # ZONEターゲットを初期化する
         self._zone_targets = {0: None, 1: None, 2: None, 3: None}
 
-    def _is_in_defence_area(self, pos: State2D) -> bool:
+    def _is_in_defense_area(self, pos: State2D) -> bool:
         # ディフェンスエリアに入ってたらtrue
         defense_x = -6.0 + 1.8 + 0.6  # 0.4はロボットの直径x2
         defense_y = 1.8 + 0.6  # 0.4はロボットの直径x2
@@ -161,7 +161,7 @@ class ZoneTargetObserver():
 
     def _is_in_zone1_0(self, pos: State2D) -> bool:
         # ZONE1 (左サイドの全部)にロボットがいればtrue
-        if self._is_in_defence_area(pos):
+        if self._is_in_defense_area(pos):
             return False
 
         if pos.x < 0.0:
@@ -170,7 +170,7 @@ class ZoneTargetObserver():
 
     def _is_in_zone2_0(self, pos: State2D) -> bool:
         # ZONE2 (左サイドの上半分)にロボットがいればtrue
-        if self._is_in_defence_area(pos):
+        if self._is_in_defense_area(pos):
             return False
         if pos.x < 0.0 and pos.y > 0.0:
             return True
@@ -178,7 +178,7 @@ class ZoneTargetObserver():
 
     def _is_in_zone2_1(self, pos: State2D) -> bool:
         # ZONE2 (左サイドの下半分)にロボットがいればtrue
-        if self._is_in_defence_area(pos):
+        if self._is_in_defense_area(pos):
             return False
         if pos.x < 0.0 and pos.y <= 0.0:
             return True
@@ -186,7 +186,7 @@ class ZoneTargetObserver():
 
     def _is_in_zone3_0(self, pos: State2D) -> bool:
         # ZONE3 (左サイドの上半分の上)にロボットがいればtrue
-        if self._is_in_defence_area(pos):
+        if self._is_in_defense_area(pos):
             return False
         if pos.x < 0.0 and pos.y > 4.5 * 0.5:
             return True
@@ -194,7 +194,7 @@ class ZoneTargetObserver():
 
     def _is_in_zone3_1(self, pos: State2D) -> bool:
         # ZONE3 (左サイドの真ん中)にロボットがいればtrue
-        if self._is_in_defence_area(pos):
+        if self._is_in_defense_area(pos):
             return False
         if pos.x < 0.0 and math.fabs(pos.y) <= 4.5 * 0.5:
             return True
@@ -202,7 +202,7 @@ class ZoneTargetObserver():
 
     def _is_in_zone3_2(self, pos: State2D) -> bool:
         # ZONE3 (左サイドの下半分の下)にロボットがいればtrue
-        if self._is_in_defence_area(pos):
+        if self._is_in_defense_area(pos):
             return False
         if pos.x < 0.0 and pos.y < -4.5 * 0.5:
             return True
@@ -210,7 +210,7 @@ class ZoneTargetObserver():
 
     def _is_in_zone4_0(self, pos: State2D) -> bool:
         # ZONE4 (左サイドの上半分の上)にロボットがいればtrue
-        if self._is_in_defence_area(pos):
+        if self._is_in_defense_area(pos):
             return False
         if pos.x < 0.0 and pos.y > 4.5 * 0.5:
             return True
@@ -218,7 +218,7 @@ class ZoneTargetObserver():
 
     def _is_in_zone4_1(self, pos: State2D) -> bool:
         # ZONE4 (左サイドの上半分の上)にロボットがいればtrue
-        if self._is_in_defence_area(pos):
+        if self._is_in_defense_area(pos):
             return False
         if pos.x < 0.0 and pos.y > 0.0 and pos.y <= 4.5 * 0.5:
             return True
@@ -226,7 +226,7 @@ class ZoneTargetObserver():
 
     def _is_in_zone4_2(self, pos: State2D) -> bool:
         # ZONE4 (左サイドの下半分の上)にロボットがいればtrue
-        if self._is_in_defence_area(pos):
+        if self._is_in_defense_area(pos):
             return False
         if pos.x < 0.0 and pos.y <= 0.0 and pos.y > -4.5 * 0.5:
             return True
@@ -234,7 +234,7 @@ class ZoneTargetObserver():
 
     def _is_in_zone4_3(self, pos: State2D) -> bool:
         # ZONE4 (左サイドの下半分の下)にロボットがいればtrue
-        if self._is_in_defence_area(pos):
+        if self._is_in_defense_area(pos):
             return False
         if pos.x < 0.0 and pos.y <= -4.5 * 0.5:
             return True


### PR DESCRIPTION
これまでゾーンDFは自分の担当エリアに入ってきたロボットに反応していましたが、  
自陣に入ってきたロボットをゴールから近い順にマークするように変更しました。  
相手ロボットとボールの間に入ろうとします。

自陣側、かつ、DFエリアより前　の区画です。  
DFエリアより後ろはサイドバックにおまかせします。

近い順に、ZONE IDが若い順にマーク位置へ移動します。  
ほかは待機します。  
本当はマークしてるロボットの台数におうじて、待機ロボットの位置を変更していったほうが良い気がしますが  
そこはやってないです。