### PR TITLE
バックパスができるようにパス関数を変更

### DIFF
--- a/consai_examples/consai_examples/decisions/attacker.py
+++ b/consai_examples/consai_examples/decisions/attacker.py
@@ -38,7 +38,7 @@ class AttackerDecision(DecisionBase):
 
     def inplay(self, robot_id):
         # 何メートル後ろの味方ロボットまでパス対象に含めるかオフセットをかける
-        search_offset = 0.5 #meter
+        search_offset = 0.5
         move_to_ball = Operation().move_on_line(
             TargetXY.ball(), TargetXY.our_robot(robot_id), 0.3, TargetTheta.look_ball())
         move_to_ball = move_to_ball.with_ball_receiving()
@@ -72,7 +72,7 @@ class AttackerDecision(DecisionBase):
 
     def our_direct(self, robot_id):
         # 何メートル後ろの味方ロボットまでパス対象に含めるかオフセットをかける
-        search_offset = 0.5 #meter
+        search_offset = 0.5
         move_to_ball = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
         move_to_ball.with_ball_receiving()
         move_to_ball = move_to_ball.with_reflecting_to(TargetXY.their_goal())

--- a/consai_examples/consai_examples/decisions/attacker.py
+++ b/consai_examples/consai_examples/decisions/attacker.py
@@ -37,6 +37,8 @@ class AttackerDecision(DecisionBase):
         self._operator.operate(robot_id, chase_ball)
 
     def inplay(self, robot_id):
+        # 何メートル後ろの味方ロボットまでパス対象に含めるかオフセットをかける
+        search_offset = 0.5 #meter
         move_to_ball = Operation().move_on_line(
             TargetXY.ball(), TargetXY.our_robot(robot_id), 0.3, TargetTheta.look_ball())
         move_to_ball = move_to_ball.with_ball_receiving()
@@ -51,7 +53,8 @@ class AttackerDecision(DecisionBase):
             return
 
         # パス可能なIDのリストを取得
-        receivers_id_list = self._field_observer.pass_shoot().search_receivers_list(robot_id)
+        receivers_id_list = self._field_observer.pass_shoot().search_receivers_list(
+            robot_id, search_offset)
 
         # パス可能な場合
         if len(receivers_id_list) > 0:
@@ -68,6 +71,8 @@ class AttackerDecision(DecisionBase):
         return
 
     def our_direct(self, robot_id):
+        # 何メートル後ろの味方ロボットまでパス対象に含めるかオフセットをかける
+        search_offset = 0.5 #meter
         move_to_ball = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
         move_to_ball.with_ball_receiving()
         move_to_ball = move_to_ball.with_reflecting_to(TargetXY.their_goal())
@@ -82,7 +87,8 @@ class AttackerDecision(DecisionBase):
             return
 
         # パス可能なIDのリストを取得
-        receivers_id_list = self._field_observer.pass_shoot().search_receivers_list(robot_id)
+        receivers_id_list = self._field_observer.pass_shoot().search_receivers_list(
+            robot_id, search_offset)
         # パスできる味方ロボットがいる場合はパスする
         if len(receivers_id_list) > 0:
             passing = move_to_ball.with_passing_for_setplay_to(

--- a/consai_examples/consai_examples/observer/pass_shoot_observer.py
+++ b/consai_examples/consai_examples/observer/pass_shoot_observer.py
@@ -142,7 +142,7 @@ class PassShootObserver:
     #     return sorted_robots_id
 
     def _search_forward_robots(
-            self, pos: State2D, search_offsset=0.0 ,search_our_robots=True,
+            self, pos: State2D, search_offsset=0.0, search_our_robots=True,
             exclude_id=-1, our_goalie_id=-1) -> list[int]:
         # 指定した座標より前にいるロボットIDのリストを返す関数
 

--- a/consai_examples/consai_examples/observer/pass_shoot_observer.py
+++ b/consai_examples/consai_examples/observer/pass_shoot_observer.py
@@ -45,7 +45,7 @@ class PassShootObserver:
     def get_shoot_pos_list(self) -> list[State2D]:
         return self._present_shoot_pos_list
 
-    def search_receivers_list(self, my_robot_id: int) -> list[int]:
+    def search_receivers_list(self, my_robot_id: int, search_offset=0.0) -> list[int]:
         # パス可能なロボットIDのリストを返す関数
         # TODO(Roots): パスできるリストの探索と、シュートできるリストの探索は別関数に分けたほうが良い
 
@@ -62,7 +62,7 @@ class PassShootObserver:
 
         # パサーよりも前にいる味方ロボットIDのリストを取得
         forward_our_id_list = self._search_forward_robots(
-            my_robot_pos, search_our_robots=True,
+            my_robot_pos, search_offset, search_our_robots=True,
             exclude_id=my_robot_id, our_goalie_id=self._goalie_id)
         forward_their_id_list = self._search_forward_robots(
             my_robot_pos, search_our_robots=False)
@@ -142,23 +142,23 @@ class PassShootObserver:
     #     return sorted_robots_id
 
     def _search_forward_robots(
-            self, pos: State2D, search_our_robots=True,
+            self, pos: State2D, search_offsset=0.0 ,search_our_robots=True,
             exclude_id=-1, our_goalie_id=-1) -> list[int]:
         # 指定した座標より前にいるロボットIDのリストを返す関数
 
-        def search(pos: State2D, robots: dict[int, PosVel]) -> list[int]:
+        def search(pos: State2D, robots: dict[int, PosVel], search_offsset=0.0) -> list[int]:
             # 指定した座標より前にいるロボットIDのリストを返す関数
             forward_robots_id = []
             for robot_id, robot in robots.items():
                 if robot_id == exclude_id or robot_id == our_goalie_id:
                     continue
-                if pos.x < robot.pos().x:
+                if pos.x < robot.pos().x + search_offsset:
                     forward_robots_id.append(robot_id)
 
             return forward_robots_id
 
         if search_our_robots:
-            return search(pos, self._our_robots)
+            return search(pos, self._our_robots, search_offsset)
         else:
             return search(pos, self._their_robots)
 


### PR DESCRIPTION
バックパスができていなかったのでできるようにパス関数を変更しました
現状は0.5m後ろのロボットまでバックパス対象にしています

**ロボットがモジモジしてなかなか蹴り出さなかった理由**

1. ボールに近づく
2. ボール直下にいるサブアタッカーがパスを出すロボットの前後をウロウロする
3. パスがなかなか出せない

となっていました。
バックパス実装に伴って解消されています。