### PR TITLE
Add man mark observer

### DIFF
--- a/consai_examples/CMakeLists.txt
+++ b/consai_examples/CMakeLists.txt
@@ -42,6 +42,7 @@ install(PROGRAMS
     ${PROJECT_NAME}/observer/ball_placement_observer.py
     ${PROJECT_NAME}/observer/ball_position_observer.py
     ${PROJECT_NAME}/observer/detection_wrapper.py
+    ${PROJECT_NAME}/observer/man_mark_observer.py
     ${PROJECT_NAME}/observer/pass_shoot_observer.py
     ${PROJECT_NAME}/observer/pos_vel.py
     ${PROJECT_NAME}/observer/side_back_target_observer.py

--- a/consai_examples/consai_examples/field_observer.py
+++ b/consai_examples/consai_examples/field_observer.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from rclpy import qos
 from rclpy.node import Node
 from robocup_ssl_msgs.msg import TrackedFrame
 
@@ -26,6 +27,8 @@ from consai_examples.observer.side_back_target_observer import SideBackTargetObs
 from consai_examples.observer.zone_target_observer import ZoneTargetObserver
 from consai_examples.observer.ball_motion_observer import BallMotionObserver
 from consai_examples.observer.pass_shoot_observer import PassShootObserver
+from consai_examples.observer.man_mark_observer import ManMarkObserver
+from consai_visualizer_msgs.msg import Objects
 
 
 class FieldObserver(Node):
@@ -41,6 +44,9 @@ class FieldObserver(Node):
         self._sub_detection_traced = self.create_subscription(
             TrackedFrame, 'detection_tracked', self._detection_tracked_callback, 10)
 
+        self._pub_visualizer_objects = self.create_publisher(
+            Objects, 'visualizer_objects', qos.qos_profile_sensor_data)
+
         self._detection_wrapper = DetectionWrapper(our_team_is_yellow)
         self._ball_position_state_observer = BallPositionObserver()
         self._ball_placement_observer = BallPlacementObserver()
@@ -49,6 +55,7 @@ class FieldObserver(Node):
         self._side_back_target_observer = SideBackTargetObserver()
         self._ball_motion_observer = BallMotionObserver()
         self._pass_shoot_observer = PassShootObserver(goalie_id)
+        self._man_mark_observer = ManMarkObserver()
 
         self._num_of_zone_roles = 0
 
@@ -75,6 +82,9 @@ class FieldObserver(Node):
 
     def pass_shoot(self) -> PassShootObserver:
         return self._pass_shoot_observer
+
+    def man_mark(self) -> ManMarkObserver:
+        return self._man_mark_observer
 
     def set_num_of_zone_roles(self, num_of_zone_roles: int) -> None:
         self._num_of_zone_roles = num_of_zone_roles
@@ -105,3 +115,15 @@ class FieldObserver(Node):
             self._detection_wrapper.ball(),
             self._detection_wrapper.our_robots(),
             self._detection_wrapper.their_robots())
+        self._man_mark_observer.update(
+            self._detection_wrapper.ball(),
+            self._detection_wrapper.our_robots(),
+            self._detection_wrapper.their_robots())
+
+        self._publish_visualizer_msgs()
+
+    def _publish_visualizer_msgs(self):
+        self._pub_visualizer_objects.publish(
+            self._man_mark_observer.to_visualize_msg(
+                self._detection_wrapper.our_robots(),
+                self._detection_wrapper.their_robots()))

--- a/consai_examples/consai_examples/observer/man_mark_observer.py
+++ b/consai_examples/consai_examples/observer/man_mark_observer.py
@@ -55,7 +55,7 @@ class ManMarkObserver:
             if our_bot_id not in our_robots.keys():
                 continue
 
-            if not self._is_free_bot(our_bot_id):
+            if not self._is_our_free_bot(our_bot_id):
                 continue
 
             # 対象のロボットに最も近いロボットをマークに割り当てる
@@ -141,7 +141,7 @@ class ManMarkObserver:
     def _is_marked(self, their_bot_id: TheirIDType) -> bool:
         return their_bot_id in self._mark_dict.values()
 
-    def _is_free_bot(self, our_id: OurIDType) -> bool:
+    def _is_our_free_bot(self, our_id: OurIDType) -> bool:
         return our_id in self._our_free_bot_ids()
 
     def _our_free_bot_ids(self) -> list[OurIDType]:

--- a/consai_examples/consai_examples/observer/man_mark_observer.py
+++ b/consai_examples/consai_examples/observer/man_mark_observer.py
@@ -34,7 +34,7 @@ class ManMarkObserver:
                our_robots: dict[OurIDType, PosVel], their_robots: dict[TheirIDType, PosVel]) -> None:
         DETECTION_THRESHOLD_X = 0.0
 
-        self._remove_non_exist_mark(their_robots)
+        self._remove_non_exist_robots_from_mark(our_robots, their_robots)
 
         # 自チームサイドの相手ロボットを全探索
         for their_bot_id, their_bot in their_robots.items():
@@ -94,11 +94,13 @@ class ManMarkObserver:
         for our_id in to_remove:
             self._mark_dict.pop(our_id)
 
-    def _remove_non_exist_mark(self, their_robots: dict[TheirIDType, PosVel]) -> None:
+    def _remove_non_exist_robots_from_mark(
+            self, our_robots: dict[OurIDType, PosVel], their_robots: dict[TheirIDType, PosVel]) -> None:
         # 存在しないキーを一時リストに保存
-        to_remove = [our_id for our_id, their_id in self._mark_dict.items() if their_id not in their_robots]
+        to_remove_via_theirs = [our_id for our_id, their_id in self._mark_dict.items() if their_id not in their_robots]
+        to_remove_via_ours = [our_id for our_id in self._mark_dict.keys() if our_id not in our_robots]
         # 実際に削除
-        for our_id in to_remove:
+        for our_id in to_remove_via_theirs + to_remove_via_ours:
             self._mark_dict.pop(our_id)
 
     def _is_marked(self, their_bot_id: TheirIDType) -> bool:
@@ -115,6 +117,9 @@ class ManMarkObserver:
         nearest_dist = math.inf
 
         for our_id in our_target_ids:
+            if our_id not in our_robots.keys():
+                continue
+
             our_pos = our_robots[our_id].pos()
             dist = tool.get_distance(our_pos, their_bot_pos)
 

--- a/consai_examples/consai_examples/observer/man_mark_observer.py
+++ b/consai_examples/consai_examples/observer/man_mark_observer.py
@@ -63,6 +63,11 @@ class ManMarkObserver:
                 our_active_bots.pop(nearest_our_bot_id)
 
     def set_our_active_bot_ids(self, our_active_bot_ids: list[OurIDType]) -> None:
+        # アクティブじゃなくなったロボットのマーク情報を削除
+        for fired_bot_id in set(self._our_active_bot_ids) - set(our_active_bot_ids):
+            if fired_bot_id in self._mark_dict.keys():
+                self._mark_dict.pop(fired_bot_id)
+
         self._our_active_bot_ids = our_active_bot_ids
 
     def get_mark_robot_id(self, our_id: OurIDType) -> TheirIDType:
@@ -137,7 +142,7 @@ class ManMarkObserver:
 
     def _our_active_free_bots(
             self, our_robots: dict[OurIDType, PosVel]) -> dict[OurIDType, PosVel]:
-        return {our_id: our_bot 
+        return {our_id: our_bot
                 for our_id, our_bot in our_robots.items() if self._is_our_free_bot(our_id)}
 
     def _is_our_free_bot(self, our_id: OurIDType) -> bool:

--- a/consai_examples/consai_examples/observer/man_mark_observer.py
+++ b/consai_examples/consai_examples/observer/man_mark_observer.py
@@ -19,6 +19,7 @@ from consai_visualizer_msgs.msg import Objects
 from consai_visualizer_msgs.msg import ShapeLine
 import math
 
+IDType = int
 OurIDType = int
 TheirIDType = int
 InValidID = -1
@@ -31,33 +32,41 @@ class ManMarkObserver:
         self._our_active_bot_ids: list[OurIDType] = []
 
     def update(self, ball: PosVel,
-               our_robots: dict[OurIDType, PosVel], their_robots: dict[TheirIDType, PosVel]) -> None:
-        DETECTION_THRESHOLD_X = 0.0
-
+               our_robots: dict[OurIDType, PosVel],
+               their_robots: dict[TheirIDType, PosVel]) -> None:
         self._remove_non_exist_robots_from_mark(our_robots, their_robots)
 
-        target_their_bots: dict[TheirIDType: PosVel] = {}
-        for their_bot_id, their_bot in their_robots.items():
-            if their_bot.pos().x > DETECTION_THRESHOLD_X:
-                self._remove_mark_via_their_id(their_bot_id)
-                continue
+        # マーク条件に該当するロボットを抽出
+        # ここの条件を変更することで、より賢いマークを実現できる
+        markable_ids = self._detect_their_bots_in_our_side(their_robots)
 
-            if self._is_marked(their_bot_id):
-                continue
+        non_markable_ids = set(their_robots.keys()) - set(markable_ids)
+        for non_markable_id in non_markable_ids:
+            self._remove_mark_via_their_id(non_markable_id)
 
-            target_their_bots[their_bot_id] = their_bot
+        # 既にマークされているロボットをマーク対象リストから削除
+        already_marked_ids = [their_id for their_id in markable_ids if self._is_marked(their_id)]
+        markable_ids = list(set(markable_ids) - set(already_marked_ids))
 
         for our_bot_id in self._our_active_bot_ids:
+            if len(markable_ids) == 0:
+                return
+
             if our_bot_id not in our_robots.keys():
                 continue
 
             if not self._is_free_bot(our_bot_id):
                 continue
 
+            # 対象のロボットに最も近いロボットをマークに割り当てる
             our_bot = our_robots[our_bot_id]
-            nearest_their_bot_id = self._search_nearest_bot_id(our_bot.pos(), target_their_bots)
+            nearest_their_bot_id = self._search_nearest_bot_id(
+                our_bot.pos(), their_robots, markable_ids)
+
+            # アサインに成功したら、マーク対象リストからIDを削除
             if self._assign_mark(our_bot_id, nearest_their_bot_id):
-                target_their_bots.pop(nearest_their_bot_id)
+                if nearest_their_bot_id in markable_ids:
+                    markable_ids.remove(nearest_their_bot_id)
 
     def set_our_active_bot_ids(self, our_active_bot_ids: list[OurIDType]) -> None:
         self._our_active_bot_ids = our_active_bot_ids
@@ -69,7 +78,8 @@ class ManMarkObserver:
             return InValidID
 
     def to_visualize_msg(
-            self, our_robots: dict[OurIDType, PosVel], their_robots: dict[TheirIDType, PosVel]) -> Objects:
+            self, our_robots: dict[OurIDType, PosVel],
+            their_robots: dict[TheirIDType, PosVel]) -> Objects:
         # アクティブロボットとマーク対象の相手ロボットを結ぶ直線を描画する
 
         vis_objects = Objects()
@@ -97,18 +107,33 @@ class ManMarkObserver:
 
         return vis_objects
 
+    def _detect_their_bots_in_our_side(
+            self, their_robots: dict[OurIDType, PosVel]) -> list[OurIDType]:
+        DETECTION_THRESHOLD_X = 0.0
+
+        bot_ids = []
+        for bot_id, bot in their_robots.items():
+            if bot.pos().x < DETECTION_THRESHOLD_X:
+                bot_ids.append(bot_id)
+
+        return bot_ids
+
     def _remove_mark_via_their_id(self, their_id: TheirIDType) -> None:
         # 削除するキーを一時リストに保存
-        to_remove = [our_id for our_id, their_id_ in self._mark_dict.items() if their_id == their_id_]
+        to_remove = [
+            our_id for our_id, their_id_ in self._mark_dict.items() if their_id == their_id_]
         # 実際に削除
         for our_id in to_remove:
             self._mark_dict.pop(our_id)
 
     def _remove_non_exist_robots_from_mark(
-            self, our_robots: dict[OurIDType, PosVel], their_robots: dict[TheirIDType, PosVel]) -> None:
+            self, our_robots: dict[OurIDType, PosVel],
+            their_robots: dict[TheirIDType, PosVel]) -> None:
         # 存在しないキーを一時リストに保存
-        to_remove_via_theirs = [our_id for our_id, their_id in self._mark_dict.items() if their_id not in their_robots]
-        to_remove_via_ours = [our_id for our_id in self._mark_dict.keys() if our_id not in our_robots]
+        to_remove_via_theirs = [
+            our_id for our_id, their_id in self._mark_dict.items() if their_id not in their_robots]
+        to_remove_via_ours = [
+            our_id for our_id in self._mark_dict.keys() if our_id not in our_robots]
         # 実際に削除
         for our_id in to_remove_via_theirs + to_remove_via_ours:
             self._mark_dict.pop(our_id)
@@ -122,34 +147,18 @@ class ManMarkObserver:
     def _our_free_bot_ids(self) -> list[OurIDType]:
         return list(set(self._our_active_bot_ids) - set(self._mark_dict.keys()))
 
-    def _search_nearest_our_bot(
-            self, their_bot_pos: State2D,
-            our_target_ids: list[OurIDType], our_robots: dict[OurIDType, PosVel]) -> OurIDType:
-
-        nearest_id = InValidID
-        nearest_dist = math.inf
-
-        for our_id in our_target_ids:
-            if our_id not in our_robots.keys():
-                continue
-
-            our_pos = our_robots[our_id].pos()
-            dist = tool.get_distance(our_pos, their_bot_pos)
-
-            if dist < nearest_dist:
-                nearest_id = our_id
-                nearest_dist = dist
-
-        return nearest_id
-
     def _search_nearest_bot_id(
             self, my_pos: State2D,
-            target_robots: dict[OurIDType, PosVel]) -> OurIDType:
+            target_robots: dict[IDType, PosVel],
+            markable_ids: list[IDType]) -> IDType:
 
         nearest_id = InValidID
         nearest_dist = math.inf
 
         for target_id, target_bot in target_robots.items():
+            if target_id not in markable_ids:
+                continue
+
             target_pos = target_bot.pos()
             dist = tool.get_distance(my_pos, target_pos)
 

--- a/consai_examples/consai_examples/observer/man_mark_observer.py
+++ b/consai_examples/consai_examples/observer/man_mark_observer.py
@@ -1,0 +1,129 @@
+# Copyright 2024 Roots
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from consai_examples.observer.pos_vel import PosVel
+from consai_msgs.msg import State2D
+from consai_tools.geometry import geometry_tools as tool
+from consai_visualizer_msgs.msg import Objects
+from consai_visualizer_msgs.msg import ShapeLine
+import math
+
+OurIDType = int
+TheirIDType = int
+InValidID = -1
+
+
+# 指定した自チームのロボットが、どの相手ロボットをマークすべきかを判定するObserver
+class ManMarkObserver:
+    def __init__(self):
+        self._mark_dict: dict[OurIDType, TheirIDType] = {}
+        self._our_active_bot_ids: list[OurIDType] = []
+
+    def update(self, ball: PosVel,
+               our_robots: dict[OurIDType, PosVel], their_robots: dict[TheirIDType, PosVel]) -> None:
+        DETECTION_THRESHOLD_X = 0.0
+
+        self._remove_non_exist_mark(their_robots)
+
+        # 自チームサイドの相手ロボットを全探索
+        for their_bot_id, their_bot in their_robots.items():
+            if their_bot.pos().x > DETECTION_THRESHOLD_X:
+                self._remove_mark_via_their_id(their_bot_id)
+                continue
+
+            if self._is_marked(their_bot_id):
+                continue
+
+            self._assign_mark(
+                self._search_nearest_our_bot(
+                    their_bot.pos(), self._our_free_bot_ids(), our_robots), their_bot_id)
+
+    def set_our_active_bot_ids(self, our_active_bot_ids: list[OurIDType]) -> None:
+        self._our_active_bot_ids = our_active_bot_ids
+
+    def get_mark_robot_id(self, our_id: OurIDType) -> TheirIDType:
+        if our_id in self._mark_dict.keys():
+            return self._mark_dict[our_id]
+        else:
+            return InValidID
+
+    def to_visualize_msg(
+            self, our_robots: dict[OurIDType, PosVel], their_robots: dict[TheirIDType, PosVel]) -> Objects:
+        # アクティブロボットとマーク対象の相手ロボットを結ぶ直線を描画する
+
+        vis_objects = Objects()
+
+        vis_objects.layer = 'game'
+        vis_objects.sub_layer = 'mark'
+        vis_objects.z_order = 4
+
+        for our_id, their_id in self._mark_dict.items():
+            if our_id not in our_robots.keys() or their_id not in their_robots.keys():
+                continue
+
+            our_pos = our_robots[our_id].pos()
+            their_pos = their_robots[their_id].pos()
+
+            line = ShapeLine()
+            line.p1.x = our_pos.x
+            line.p1.y = our_pos.y
+            line.p2.x = their_pos.x
+            line.p2.y = their_pos.y
+            line.size = 5
+            line.color.name = 'deepskyblue'
+            line.caption = 'mark' + str(our_id) + '->' + str(their_id)
+            vis_objects.lines.append(line)
+
+        return vis_objects
+
+    def _remove_mark_via_their_id(self, their_id: TheirIDType) -> None:
+        # 削除するキーを一時リストに保存
+        to_remove = [our_id for our_id, their_id_ in self._mark_dict.items() if their_id == their_id_]
+        # 実際に削除
+        for our_id in to_remove:
+            self._mark_dict.pop(our_id)
+
+    def _remove_non_exist_mark(self, their_robots: dict[TheirIDType, PosVel]) -> None:
+        # 存在しないキーを一時リストに保存
+        to_remove = [our_id for our_id, their_id in self._mark_dict.items() if their_id not in their_robots]
+        # 実際に削除
+        for our_id in to_remove:
+            self._mark_dict.pop(our_id)
+
+    def _is_marked(self, their_bot_id: TheirIDType) -> bool:
+        return their_bot_id in self._mark_dict.values()
+
+    def _our_free_bot_ids(self) -> list[OurIDType]:
+        return list(set(self._our_active_bot_ids) - set(self._mark_dict.keys()))
+
+    def _search_nearest_our_bot(
+            self, their_bot_pos: State2D,
+            our_target_ids: list[OurIDType], our_robots: dict[OurIDType, PosVel]) -> OurIDType:
+
+        nearest_id = InValidID
+        nearest_dist = math.inf
+
+        for our_id in our_target_ids:
+            our_pos = our_robots[our_id].pos()
+            dist = tool.get_distance(our_pos, their_bot_pos)
+
+            if dist < nearest_dist:
+                nearest_id = our_id
+                nearest_dist = dist
+
+        return nearest_id
+
+    def _assign_mark(self, our_id: OurIDType, their_id: TheirIDType) -> None:
+        if our_id != InValidID:
+            self._mark_dict[our_id] = their_id

--- a/consai_examples/consai_examples/role_to_visualize_msg.py
+++ b/consai_examples/consai_examples/role_to_visualize_msg.py
@@ -23,7 +23,7 @@ from consai_visualizer_msgs.msg import ShapeText
 def to_visualize_msg(role_dict: dict[int, str], our_robots: dict[int, PosVel]) -> Objects:
     vis_objects = Objects()
 
-    vis_objects.layer = 'role'
+    vis_objects.layer = 'game'
     vis_objects.sub_layer = 'role'
     vis_objects.z_order = 5
 


### PR DESCRIPTION
マンマーク用のObserverを追加します。

次のようにマーク対象のIDを取得できます

```python
# マークに行動できる味方ロボットIDをセット
observer.man_mark().set_our_active_bot_ids([1, 2, 3])

# 裏でobserverが更新される

# マーク対象となる相手ロボットIDを取得
target1 = observer.man_mark().get_mark_robot_id(1)
target2 = observer.man_mark().get_mark_robot_id(2)

# マーク対象がいない場合は-1が帰ってくる
if target1 == -1:
  return
```

### マーク対象を選ぶアルゴリズム

現在は、座標がx < 0 となる相手ロボットをマーク対象とし、
それに一番近い味方ロボットを割り当てています。

アルゴリズムは適宜変更してください。
（例：ボールまでの距離が3 m 以内のロボット）

## その他変更

ビジュアライザにマーク対象の結果を表示します。
デバッグにも役立ちます。

![image](https://github.com/SSL-Roots/consai_ros2/assets/18494952/ac12c322-9214-427c-9215-9c0f57f2b08d)

## テスト

本来は単体テストを書くべきですが、サボってます。

ざっくりと下記のテストを実行してます。

- 味方ロボットの増減に対応しているか
- 相手ロボットの増減に対応しているか
- 自エリアの侵入と脱出に対応しているか
- 自エリアに侵入した相手ロボットの移動に対応しているか
- ロールの切り替わりに対応しているか

## その他

このobserverを使うことで、
#241 のゾーンマンマークをより強くできると思います。

