### PR TITLE
Set max priority for defense area avoidance

### DIFF
--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -136,13 +136,11 @@ State FieldInfoParser::modify_goal_pose_to_avoid_obstacles(
     return avoidance_pose;
   }
 
-  if (goal->avoid_defense_area) {
-    tactic_obstacle_avoidance_->avoid_defense_area(my_robot, avoidance_pose, avoidance_pose);
-  }
-
   TrackedBall ball;
   if (!detection_extractor_->extract_ball(ball)) {
-    return avoidance_pose;
+    // Set dummy value
+    ball.pos.x = 1000.0;
+    ball.pos.y = 1000.0;
   }
 
   tactic_obstacle_avoidance_->avoid_obstacles(
@@ -160,6 +158,10 @@ State FieldInfoParser::modify_goal_pose_to_avoid_obstacles(
   if (goal->avoid_ball) {
     tactic_obstacle_avoidance_->avoid_ball_500mm(
       my_robot, final_goal_pose, avoidance_pose, ball, avoidance_pose);
+  }
+
+  if (goal->avoid_defense_area) {
+    tactic_obstacle_avoidance_->avoid_defense_area(my_robot, avoidance_pose, avoidance_pose);
   }
 
   return avoidance_pose;

--- a/consai_robot_controller/src/tactic/tactic_obstacle_avoidance.cpp
+++ b/consai_robot_controller/src/tactic/tactic_obstacle_avoidance.cpp
@@ -395,7 +395,7 @@ bool ObstacleAvoidance::avoid_defense_area(
       const auto len_our_intersections = is_intersect_top + is_intersect_bottom +
         is_intersect_inside;
 
-      constexpr double AVOID_DISTANCE = 0.5;
+      constexpr double AVOID_DISTANCE = ROBOT_RADIUS * 2.0;
       const auto AVOID_POS_X = (-FIELD_HALF_LENGTH + DEFENSE_AREA_HALF_WIDTH + AVOID_DISTANCE) *
         sign;
       constexpr auto AVOID_POS_Y = DEFENSE_AREA_HALF_WIDTH + AVOID_DISTANCE;


### PR DESCRIPTION
ディンフェスエリアの衝突回避を最大にします

## 懸念点

ボール周囲500 mm回避よりも優先度が高くなるので、ディンフェスエリア付近にボールがあるときの挙動が怪しいかもしれません。

（STOP中はディフェンスエリアからボールを700 mm以上離すので、大丈夫だと思いますが）