### PR TITLE
敵ロボット位置のキー検索を変更（ゴーリー）

### DIFF
--- a/consai_examples/consai_examples/decisions/goalie.py
+++ b/consai_examples/consai_examples/decisions/goalie.py
@@ -57,12 +57,13 @@ class GoaleDecision(DecisionBase):
         flag = 1
         # 味方エリアにボールが存在かつボールに近い敵ロボットが存在する場合
         if is_in_our_side and len(distance_ball_to_their_robots.keys()):
-            # ボールに一番近い敵ロボットのIDを取得
-            sorted_distance = sorted(
-                enumerate(distance_ball_to_their_robots.keys()), key=lambda x: x[1])
-            sorted_indices = [index for index, _ in sorted_distance]
+            # ロボットの位置を取得
             robots = self._field_observer.detection().their_robots()
-            for i in sorted_indices:
+            for _ in range(len(distance_ball_to_their_robots)):
+                # ボールに一番近い敵ロボットのIDを取得
+                i = min(distance_ball_to_their_robots, key=distance_ball_to_their_robots.get)
+                _ = distance_ball_to_their_robots.pop(i)
+                # キーが存在している場合
                 if i in robots:
                     # 一番近いロボットの位置を取得
                     robot_pos = robots[i].pos()
@@ -78,7 +79,7 @@ class GoaleDecision(DecisionBase):
                             x = p1_x
                             defend_pose = TargetXY.value(x, y)
                             flag = 2
-                    continue
+                    break
 
         # ボールがゴールに向かって来る場合
         elif 0.2 < abs(ball_vel.x) and 0.1 < math.hypot(ball_vel.x, ball_vel.y):

--- a/consai_examples/consai_examples/decisions/goalie.py
+++ b/consai_examples/consai_examples/decisions/goalie.py
@@ -35,13 +35,14 @@ class GoaleDecision(DecisionBase):
         self.our_goal_center_pos = Field()._our_goal_dict['center']
         self.our_goal_lower_pos = Field()._our_goal_dict['lower']
         # ゴール前を守る位置のマージン[m]
-        self.margin = 0.2
+        self.margin_x = 0.2
+        self.margin_y = 0.35
 
     def _defend_goal_operation(self):
-        p1_x = self.our_goal_upper_pos.x + self.margin
-        p1_y = self.our_goal_upper_pos.y
-        p2_x = self.our_goal_lower_pos.x + self.margin
-        p2_y = self.our_goal_lower_pos.y
+        p1_x = self.our_goal_upper_pos.x + self.margin_x
+        p1_y = self.our_goal_upper_pos.y - self.margin_y
+        p2_x = self.our_goal_lower_pos.x + self.margin_x
+        p2_y = self.our_goal_lower_pos.y + self.margin_y
 
         # ボールの座標を取得
         ball_pos = self._field_observer.detection().ball().pos()
@@ -62,20 +63,20 @@ class GoaleDecision(DecisionBase):
             for _ in range(len(distance_ball_to_their_robots)):
                 # ボールに一番近い敵ロボットのIDを取得
                 i = min(distance_ball_to_their_robots, key=distance_ball_to_their_robots.get)
-                _ = distance_ball_to_their_robots.pop(i)
+                distance = distance_ball_to_their_robots.pop(i)
                 # キーが存在している場合
                 if i in robots:
                     # 一番近いロボットの位置を取得
                     robot_pos = robots[i].pos()
 
                     # 敵ロボットの距離が近いかつ距離の近い敵ロボットよりボールがゴール側にある場合
-                    if min(distance_ball_to_their_robots) < 0.15 and ball_pos.x < robot_pos.x:
+                    if distance < 0.15 and ball_pos.x < robot_pos.x:
                         # 2点を結ぶ直線の傾きと切片を取得
                         slope, intercept, _ = geometry_tools.get_line_parameter(
                             ball_pos, robot_pos)
                         # ゴール前との交点(y座標)を算出
                         y = slope * p1_x + intercept
-                        if abs(y) < p1_y - 0.35:
+                        if abs(y) < p1_y:
                             x = p1_x
                             defend_pose = TargetXY.value(x, y)
                             flag = 2
@@ -87,7 +88,7 @@ class GoaleDecision(DecisionBase):
             slope, intercept, _ = geometry_tools.get_line_parameter(ball_pos, ball_vel)
             # ゴール前との交点(y座標)を算出
             y = slope * p1_x + intercept
-            if abs(y) < p1_y:
+            if abs(y) < p1_y + self.margin_y:
                 x = p1_x
                 defend_pose = TargetXY.value(x, y)
                 flag = 2


### PR DESCRIPTION
以前の敵ロボットのキー検索にバグがある可能性があった
以前は距離順にソートしてインデックスを取得しようとしていたが、今回は最小値のインデックスだけ順番に取得して検索している