### PR TITLE
Update sub attacker

### DIFF
--- a/consai_examples/consai_examples/decisions/sub_attacker.py
+++ b/consai_examples/consai_examples/decisions/sub_attacker.py
@@ -15,18 +15,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from enum import Enum
+
 from decisions.decision_base import DecisionBase
 from operation import Operation
 from operation import TargetXY
 from operation import TargetTheta
 
+class SubAttackerID(Enum):
+    SUBATTACK1 = 0
+    SUBATTACK2 = 1
 
 class SubAttackerDecision(DecisionBase):
 
-    def __init__(self, robot_operator, field_observer):
+    def __init__(self, robot_operator, field_observer, sub_attacker_id: SubAttackerID):
         super().__init__(robot_operator, field_observer)
+        self._sub_attacker_id = sub_attacker_id
+        self.half_right = 3.0
+        self.dist_from_ball_x = 1.5
+        self.dist_from_ball_y = 2.5
 
     def _offend_operation(self):
+        SUB_ATTACKER_ID = self._sub_attacker_id.value
         # ボールがフィールド上半分にあるときは、フィールド下側に移動する
         move_to_ball = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
         if self._field_observer.zone().ball_is_in_top():

--- a/consai_examples/consai_examples/decisions/sub_attacker.py
+++ b/consai_examples/consai_examples/decisions/sub_attacker.py
@@ -22,9 +22,11 @@ from operation import Operation
 from operation import TargetXY
 from operation import TargetTheta
 
+
 class SubAttackerID(Enum):
     SUBATTACK1 = 0
     SUBATTACK2 = 1
+
 
 class SubAttackerDecision(DecisionBase):
 
@@ -146,7 +148,7 @@ class SubAttackerDecision(DecisionBase):
                 return
 
         if self._sub_attacker_id == SubAttackerID.SUBATTACK1:
-        # ボール位置が配置目標位置に到着したらボールから離れる
+            # ボール位置が配置目標位置に到着したらボールから離れる
             avoid_ball = Operation().move_on_line(
                 TargetXY.ball(), TargetXY.our_robot(robot_id), 0.6, TargetTheta.look_ball())
             self._operator.operate(robot_id, avoid_ball)

--- a/consai_examples/consai_examples/decisions/sub_attacker.py
+++ b/consai_examples/consai_examples/decisions/sub_attacker.py
@@ -145,10 +145,17 @@ class SubAttackerDecision(DecisionBase):
                 self._operator.operate(robot_id, move_to_behind_target)
                 return
 
+        if self._sub_attacker_id == SubAttackerID.SUBATTACK1:
         # ボール位置が配置目標位置に到着したらボールから離れる
-        avoid_ball = Operation().move_on_line(
-            TargetXY.ball(), TargetXY.our_robot(robot_id), 0.6, TargetTheta.look_ball())
-        self._operator.operate(robot_id, avoid_ball)
+            avoid_ball = Operation().move_on_line(
+                TargetXY.ball(), TargetXY.our_robot(robot_id), 0.6, TargetTheta.look_ball())
+            self._operator.operate(robot_id, avoid_ball)
+        else:
+            operation = self._offend_operation()
+            operation = operation.enable_avoid_ball()
+            operation = operation.enable_avoid_placement_area(placement_pos)
+            operation = operation.enable_avoid_pushing_robots()
+            self._operator.operate(robot_id, operation)
 
     def their_ball_placement(self, robot_id, placement_pos):
         operation = self._offend_operation()

--- a/consai_examples/consai_examples/decisions/sub_attacker.py
+++ b/consai_examples/consai_examples/decisions/sub_attacker.py
@@ -51,10 +51,10 @@ class SubAttackerDecision(DecisionBase):
         else:
             if self._sub_attacker_id == SubAttackerID.SUBATTACK1:
                 move_to_ball = Operation().move_to_pose(TargetXY.value(
-                    self._penalty_side_x, self._penalty_side_y), TargetTheta.look_ball())
+                    self._penalty_front_x, -self._penalty_front_y), TargetTheta.look_ball())
             else:
                 move_to_ball = Operation().move_to_pose(TargetXY.value(
-                    self._penalty_front_x, -self._penalty_front_y), TargetTheta.look_ball())
+                    self._penalty_side_x, self._penalty_side_y), TargetTheta.look_ball())
         return move_to_ball
 
     def _offend_our_side_operation(self):

--- a/consai_examples/consai_examples/decisions/sub_attacker.py
+++ b/consai_examples/consai_examples/decisions/sub_attacker.py
@@ -31,34 +31,54 @@ class SubAttackerDecision(DecisionBase):
     def __init__(self, robot_operator, field_observer, sub_attacker_id: SubAttackerID):
         super().__init__(robot_operator, field_observer)
         self._sub_attacker_id = sub_attacker_id
-        self.half_right = 3.0
-        self.dist_from_ball_x = 1.5
-        self.dist_from_ball_y = 2.5
+        self._penalty_side_x = 5.1
+        self._penalty_side_y = 3.0
+        self._penalty_front_x = 3.8
+        self._penalty_front_y = 2.8
 
     def _offend_operation(self):
-        SUB_ATTACKER_ID = self._sub_attacker_id.value
+        ball_pos = self._field_observer.detection().ball().pos()
         # ボールがフィールド上半分にあるときは、フィールド下側に移動する
-        move_to_ball = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
-        if self._field_observer.zone().ball_is_in_top():
-            move_to_ball = move_to_ball.overwrite_pose_y(-2.5)
+        if ball_pos.y > 0:
+            if self._sub_attacker_id == SubAttackerID.SUBATTACK1:
+                move_to_ball = Operation().move_to_pose(TargetXY.value(
+                    self._penalty_side_x, -self._penalty_side_y), TargetTheta.look_ball())
+            else:
+                move_to_ball = Operation().move_to_pose(TargetXY.value(
+                    self._penalty_front_x, self._penalty_front_y), TargetTheta.look_ball())
         else:
-            move_to_ball = move_to_ball.overwrite_pose_y(2.5)
+            if self._sub_attacker_id == SubAttackerID.SUBATTACK1:
+                move_to_ball = Operation().move_to_pose(TargetXY.value(
+                    self._penalty_side_x, self._penalty_side_y), TargetTheta.look_ball())
+            else:
+                move_to_ball = Operation().move_to_pose(TargetXY.value(
+                    self._penalty_front_x, -self._penalty_front_y), TargetTheta.look_ball())
         return move_to_ball
 
     def _offend_our_side_operation(self):
         # ボールがフィールド上半分にあるときは、フィールド下側に移動する
         move_to_ball = Operation().move_to_pose(TargetXY.ball(), TargetTheta.look_ball())
-        if self._field_observer.zone().ball_is_in_left_bottom() or \
-                self._field_observer.zone().ball_is_in_left_mid_bottom():
-            move_to_ball = move_to_ball.overwrite_pose_y(2.5)
+        if self._sub_attacker_id == SubAttackerID.SUBATTACK1:
+            if self._field_observer.zone().ball_is_in_left_bottom() or \
+                    self._field_observer.zone().ball_is_in_left_mid_bottom():
+                move_to_ball = move_to_ball.overwrite_pose_y(2.5)
+            else:
+                move_to_ball = move_to_ball.overwrite_pose_y(-2.5)
         else:
-            move_to_ball = move_to_ball.overwrite_pose_y(-2.5)
-
+            if self._field_observer.zone().ball_is_in_left_bottom() or \
+                    self._field_observer.zone().ball_is_in_left_mid_bottom():
+                move_to_ball = move_to_ball.overwrite_pose_y(-2.5)
+            else:
+                move_to_ball = move_to_ball.overwrite_pose_y(2.5)
         move_to_ball = move_to_ball.offset_pose_x(-0.3)
         return move_to_ball
 
     def stop(self, robot_id):
-        operation = self._offend_operation()
+        ball_pos = self._field_observer.detection().ball().pos()
+        if ball_pos.x > 0.5:
+            operation = self._offend_operation()
+        else:
+            operation = self._offend_our_side_operation()
         operation = operation.enable_avoid_ball()
         operation = operation.enable_avoid_pushing_robots()
         self._operator.operate(robot_id, operation)
@@ -114,15 +134,16 @@ class SubAttackerDecision(DecisionBase):
     def our_ball_placement(self, robot_id, placement_pos):
         if self._field_observer.ball_placement().is_far_from(placement_pos) or \
            not self._field_observer.ball_placement().is_arrived_at(placement_pos):
-            # ボールを受け取る
-            move_to_behind_target = Operation().move_on_line(
-                TargetXY.value(placement_pos.x, placement_pos.y),
-                TargetXY.ball(),
-                -0.1,
-                TargetTheta.look_ball())
-            move_to_behind_target = move_to_behind_target.with_ball_receiving()
-            self._operator.operate(robot_id, move_to_behind_target)
-            return
+            if self._sub_attacker_id == SubAttackerID.SUBATTACK1:
+                # ボールを受け取る
+                move_to_behind_target = Operation().move_on_line(
+                    TargetXY.value(placement_pos.x, placement_pos.y),
+                    TargetXY.ball(),
+                    -0.1,
+                    TargetTheta.look_ball())
+                move_to_behind_target = move_to_behind_target.with_ball_receiving()
+                self._operator.operate(robot_id, move_to_behind_target)
+                return
 
         # ボール位置が配置目標位置に到着したらボールから離れる
         avoid_ball = Operation().move_on_line(

--- a/consai_examples/consai_examples/game.py
+++ b/consai_examples/consai_examples/game.py
@@ -25,7 +25,7 @@ from decisions.center_back import CenterBackDecision, CenterBackID
 from decisions.goalie import GoaleDecision
 from decisions.side_back import SideBackDecision, SideBackID
 from decisions.side_wing import SideWingDecision, WingID
-from decisions.sub_attacker import SubAttackerDecision
+from decisions.sub_attacker import SubAttackerDecision, SubAttackerID
 from decisions.substitute import SubstituteDecision
 from decisions.zone_defense import ZoneDefenseDecision, ZoneDefenseID
 from field_observer import FieldObserver
@@ -56,8 +56,7 @@ def num_of_active_zone_roles(active_roles):
     role_zone_list = [
         RoleName.ZONE1,
         RoleName.ZONE2,
-        RoleName.ZONE3,
-        RoleName.ZONE4]
+        RoleName.ZONE3]
     return len(set(role_zone_list) & set(active_roles))
 
 
@@ -65,7 +64,7 @@ def zone_role_ids(aVctive_roles) -> list[int]:
     # ゾーンディンフェンスを担当するロボットIDのリストを返す
     ids = []
     for role, robot_id in assignor.get_assigned_roles_and_ids():
-        if role in [RoleName.ZONE1, RoleName.ZONE2, RoleName.ZONE3, RoleName.ZONE4]:
+        if role in [RoleName.ZONE1, RoleName.ZONE2, RoleName.ZONE3]:
             ids.append(robot_id)
     return ids
 
@@ -223,11 +222,11 @@ if __name__ == '__main__':
         RoleName.ATTACKER: AttackerDecision(operator, observer),
         RoleName.CENTER_BACK1: CenterBackDecision(operator, observer, CenterBackID.CENTER_BACK1),
         RoleName.CENTER_BACK2: CenterBackDecision(operator, observer, CenterBackID.CENTER_BACK2),
-        RoleName.SUB_ATTACKER: SubAttackerDecision(operator, observer),
+        RoleName.SUB_ATTACKER1: SubAttackerDecision(operator, observer, SubAttackerID.SUBATTACK1),
+        RoleName.SUB_ATTACKER2: SubAttackerDecision(operator, observer, SubAttackerID.SUBATTACK2),
         RoleName.ZONE1: ZoneDefenseDecision(operator, observer, ZoneDefenseID.ZONE1),
         RoleName.ZONE2: ZoneDefenseDecision(operator, observer, ZoneDefenseID.ZONE2),
         RoleName.ZONE3: ZoneDefenseDecision(operator, observer, ZoneDefenseID.ZONE3),
-        RoleName.ZONE4: ZoneDefenseDecision(operator, observer, ZoneDefenseID.ZONE4),
         RoleName.LEFT_WING: SideWingDecision(operator, observer, WingID.LEFT),
         RoleName.RIGHT_WING: SideWingDecision(operator, observer, WingID.RIGHT),
         RoleName.SIDE_BACK1: SideBackDecision(operator, observer, SideBackID.SIDE1),

--- a/consai_examples/consai_examples/role_assignment.py
+++ b/consai_examples/consai_examples/role_assignment.py
@@ -41,7 +41,7 @@ class RoleName(Enum):
     ZONE1 = 5
     ZONE2 = 6
     ZONE3 = 7
-    SUB_ATTACKER2= 8
+    SUB_ATTACKER2 = 8
     LEFT_WING = 11
     RIGHT_WING = 12
     SIDE_BACK1 = 13

--- a/consai_examples/consai_examples/role_assignment.py
+++ b/consai_examples/consai_examples/role_assignment.py
@@ -37,11 +37,11 @@ class RoleName(Enum):
     ATTACKER = 1
     CENTER_BACK1 = 2
     CENTER_BACK2 = 3
-    SUB_ATTACKER = 4
+    SUB_ATTACKER1 = 4
     ZONE1 = 5
     ZONE2 = 6
     ZONE3 = 7
-    ZONE4 = 8
+    SUB_ATTACKER2= 8
     LEFT_WING = 11
     RIGHT_WING = 12
     SIDE_BACK1 = 13
@@ -64,15 +64,15 @@ class RoleAssignment(Node):
     ACTIVE_ROLE_LIST = [
         RoleName.GOALIE,
         RoleName.ATTACKER,
-        RoleName.SUB_ATTACKER,
+        RoleName.SUB_ATTACKER1,
         RoleName.CENTER_BACK1,
         RoleName.CENTER_BACK2,
         RoleName.SIDE_BACK1,
         RoleName.SIDE_BACK2,
+        RoleName.SUB_ATTACKER2,
         RoleName.ZONE1,
         RoleName.ZONE2,
         RoleName.ZONE3,
-        RoleName.ZONE4,
         # RoleName.LEFT_WING,
         # RoleName.RIGHT_WING,
     ]


### PR DESCRIPTION
サブアタッカーを2第荷増やしました。
それに伴ってゾーンディフェンスの台数を4台から3台に減らしました。

サブアタッカーは相手ペナルティーエリア周辺に移動します。
フェール度中心から相手側コートの0.5mまでは自分たち側にボールがあるものとして処理しています。
→キックオフのときに相手側に居座り続けて大量に違反が取られるため