### PR TITLE
Use back dribble for ball_placement

### DIFF
--- a/consai_examples/consai_examples/decisions/attacker.py
+++ b/consai_examples/consai_examples/decisions/attacker.py
@@ -156,16 +156,14 @@ class AttackerDecision(DecisionBase):
 
     def our_ball_placement(self, robot_id, placement_pos):
         # 壁際にあると判定した場合
-        # ボールがフィールド外にある場合は、壁に向かってボールを蹴る
+        # ボールがフィールド外にある場合は、バックドリブルでボールをフィールド内に戻す
         if self._field_observer.ball_position().is_outside_with_margin():
-            kick_pos = self._kick_pos_to_reflect_on_wall(placement_pos)
             move_to_ball = Operation().move_on_line(
                 TargetXY.ball(), TargetXY.our_robot(robot_id), 0.5, TargetTheta.look_ball())
             move_to_ball = move_to_ball.with_ball_receiving()
-            put_ball_back = move_to_ball.with_shooting_for_setplay_to(
-                TargetXY.value(kick_pos.x, kick_pos.y))
-            put_ball_back = put_ball_back.disable_avoid_defense_area()
-            self._operator.operate(robot_id, put_ball_back)
+            back_dribble = move_to_ball.with_back_dribbling_to(TargetXY.value(0.0, 0.0))
+            back_dribble = back_dribble.disable_avoid_defense_area()
+            self._operator.operate(robot_id, back_dribble)
             return
 
         if self._field_observer.ball_placement().is_far_from(placement_pos):

--- a/consai_examples/consai_examples/decisions/attacker.py
+++ b/consai_examples/consai_examples/decisions/attacker.py
@@ -16,7 +16,9 @@
 # limitations under the License.
 
 from consai_msgs.msg import State2D
+import copy
 from decisions.decision_base import DecisionBase
+import math
 from operation import Operation
 from operation import TargetXY
 from operation import TargetTheta
@@ -157,11 +159,28 @@ class AttackerDecision(DecisionBase):
     def our_ball_placement(self, robot_id, placement_pos):
         # 壁際にあると判定した場合
         # ボールがフィールド外にある場合は、バックドリブルでボールをフィールド内に戻す
-        if self._field_observer.ball_position().is_outside_with_margin():
+        if self._field_observer.ball_position().is_outside():
             move_to_ball = Operation().move_on_line(
                 TargetXY.ball(), TargetXY.our_robot(robot_id), 0.5, TargetTheta.look_ball())
             move_to_ball = move_to_ball.with_ball_receiving()
-            back_dribble = move_to_ball.with_back_dribbling_to(TargetXY.value(0.0, 0.0))
+
+            # 壁に対して垂直方向にドリブルする
+            ball_pos = self._field_observer.detection().ball().pos()
+            dribble_pos = copy.deepcopy(ball_pos)
+
+            # 壁からどれだけボールを離すのか
+            MARGIN = 0.7
+
+            if self._field_observer.ball_position().is_outside_of_left() or\
+               self._field_observer.ball_position().is_outside_of_right():
+                dribble_pos.x = math.copysign(
+                    self._field_observer.field_half_length() - MARGIN, dribble_pos.x)
+            else:
+                dribble_pos.y = math.copysign(
+                    self._field_observer.field_half_width() - MARGIN, dribble_pos.y)
+
+            back_dribble = move_to_ball.with_back_dribbling_to(
+                TargetXY.value(dribble_pos.x, dribble_pos.y))
             back_dribble = back_dribble.disable_avoid_defense_area()
             self._operator.operate(robot_id, back_dribble)
             return

--- a/consai_examples/consai_examples/operation.py
+++ b/consai_examples/consai_examples/operation.py
@@ -311,6 +311,12 @@ class Operation():
         goal.dribble_target = target_xy.constraint
         return Operation(goal)
 
+    def with_back_dribbling_to(self, target_xy: TargetXY) -> 'Operation':
+        goal = deepcopy(self._goal)
+        goal.back_dribble_enable = True
+        goal.dribble_target = target_xy.constraint
+        return Operation(goal)
+
     def with_reflecting_to(self, target_xy: TargetXY) -> 'Operation':
         goal = deepcopy(self._goal)
         goal.reflect_shoot = True

--- a/consai_msgs/msg/RobotControlMsg.msg
+++ b/consai_msgs/msg/RobotControlMsg.msg
@@ -26,6 +26,7 @@ ConstraintXY kick_target
 
 # dribble_enable = trueで、dribble_targetに向かってボールを運ぶ
 bool dribble_enable false
+bool back_dribble_enable false
 bool ball_boy_dribble_enable false
 ConstraintXY dribble_target
 

--- a/consai_robot_controller/CMakeLists.txt
+++ b/consai_robot_controller/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(controller_component SHARED
   src/detection_extractor.cpp
   src/constraint_parser.cpp
   src/obstacle/obstacle_observer.cpp
+  src/tactic/back_dribble_tactics.cpp
   src/tactic/ball_boy_tactics.cpp
   src/tactic/dribble_tactics.cpp
   src/tactic/shoot_tactics.cpp

--- a/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
@@ -25,6 +25,7 @@
 #include "consai_robot_controller/constraint_parser.hpp"
 #include "consai_robot_controller/detection_extractor.hpp"
 #include "consai_robot_controller/obstacle/obstacle_environment.hpp"
+#include "consai_robot_controller/tactic/back_dribble_tactics.hpp"
 #include "consai_robot_controller/tactic/ball_boy_tactics.hpp"
 #include "consai_robot_controller/tactic/dribble_tactics.hpp"
 #include "consai_robot_controller/tactic/shoot_tactics.hpp"
@@ -83,6 +84,7 @@ private:
   std::shared_ptr<ParsedReferee> parsed_referee_;
   tactics::BallBoyTactics ball_boy_tactics_;
   dribble_tactics::DribbleTactics dribble_tactics_;
+  back_dribble_tactics::BackDribbleTactics back_dribble_tactics_;
   shoot_tactics::ShootTactics shoot_tactics_;
   std::shared_ptr<parser::ConstraintParser> constraint_parser_;
   std::shared_ptr<tactic::ControlBall> tactic_control_ball_;

--- a/consai_robot_controller/include/consai_robot_controller/tactic/back_dribble_tactics.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/tactic/back_dribble_tactics.hpp
@@ -1,0 +1,56 @@
+// Copyright 2024 Roots
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONSAI_ROBOT_CONTROLLER__TACTIC__BACK_DRIBBLE_TACTICS_HPP_
+#define CONSAI_ROBOT_CONTROLLER__TACTIC__BACK_DRIBBLE_TACTICS_HPP_
+
+#include <chrono>
+#include <functional>
+#include <map>
+#include <string>
+
+#include "consai_msgs/msg/state2_d.hpp"
+#include "consai_robot_controller/tactic/tactic_data_set.hpp"
+#include "robocup_ssl_msgs/msg/tracked_ball.hpp"
+#include "robocup_ssl_msgs/msg/tracked_robot.hpp"
+
+namespace back_dribble_tactics
+{
+
+using Time = std::chrono::system_clock::time_point;
+using State = consai_msgs::msg::State2D;
+using TrackedBall = robocup_ssl_msgs::msg::TrackedBall;
+using TrackedRobot = robocup_ssl_msgs::msg::TrackedRobot;
+using RobotID = unsigned int;
+using TacticName = std::string;
+using TacticDataSet = tactics::TacticDataSet;
+
+class BackDribbleTactics
+{
+public:
+  BackDribbleTactics();
+  ~BackDribbleTactics() = default;
+  bool update(
+    const State & dribble_target, const TrackedRobot & my_robot, const TrackedBall & ball,
+    State & parsed_pose, double & parsed_dribble_power);
+
+private:
+  std::map<RobotID, TacticName> tactic_name_;
+  std::map<RobotID, Time> tactic_time_;
+  std::map<TacticName, std::function<TacticName(TacticDataSet & data_set)>> tactic_functions_;
+};
+
+}  // namespace back_dribble_tactics
+
+#endif  // CONSAI_ROBOT_CONTROLLER__TACTIC__BACK_DRIBBLE_TACTICS_HPP_

--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -115,7 +115,10 @@ bool FieldInfoParser::parse_goal(
   }
 
   if (goal->dribble_enable && has_dribble_target) {
-    // dribble_tactics_.update(dribble_target, my_robot, ball, parsed_pose, dribble_power);
+    dribble_tactics_.update(dribble_target, my_robot, ball, parsed_pose, dribble_power);
+  }
+
+  if (goal->back_dribble_enable && has_dribble_target) {
     back_dribble_tactics_.update(dribble_target, my_robot, ball, parsed_pose, dribble_power);
   }
 

--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -115,7 +115,8 @@ bool FieldInfoParser::parse_goal(
   }
 
   if (goal->dribble_enable && has_dribble_target) {
-    dribble_tactics_.update(dribble_target, my_robot, ball, parsed_pose, dribble_power);
+    // dribble_tactics_.update(dribble_target, my_robot, ball, parsed_pose, dribble_power);
+    back_dribble_tactics_.update(dribble_target, my_robot, ball, parsed_pose, dribble_power);
   }
 
   if (goal->ball_boy_dribble_enable && has_dribble_target) {

--- a/consai_robot_controller/src/tactic/back_dribble_tactics.cpp
+++ b/consai_robot_controller/src/tactic/back_dribble_tactics.cpp
@@ -1,0 +1,215 @@
+// Copyright 2024 Roots
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+
+#include "consai_robot_controller/tactic/back_dribble_tactics.hpp"
+#include "consai_tools/geometry_tools.hpp"
+
+namespace back_dribble_tactics
+{
+
+namespace tools = geometry_tools;
+namespace chrono = std::chrono;
+
+static constexpr double ROBOT_RADIUS = 0.09;  // ロボットの半径
+static constexpr double DRIBBLE_CATCH = 1.0;
+static constexpr double DRIBBLE_RELEASE = 0.0;
+static constexpr double ROTATE_RADIUS = ROBOT_RADIUS * 2.0;  // meters
+static constexpr double BALL_RADIUS = 0.0215;  // meters
+static constexpr auto APPROACH = "APPROACH";
+static constexpr auto ROTATE = "ROTATE";
+static constexpr auto CATCH = "CATCH";
+static constexpr auto CARRY = "CARRY";
+static constexpr auto RELEASE = "RELEASE";
+
+
+BackDribbleTactics::BackDribbleTactics()
+{
+  tactic_functions_[APPROACH] = [this](TacticDataSet & data_set) -> TacticName {
+      // 現在位置からボールに対してまっすぐ進む
+      constexpr auto DISTANCE_THRESHOLD = 0.1;  // meters
+      const auto THETA_THRESHOLD = tools::to_radians(5.0);
+
+      const auto robot_pose = tools::pose_state(data_set.get_my_robot());
+      const auto ball_pose = tools::pose_state(data_set.get_ball());
+
+      const tools::Trans trans_BtoR(ball_pose, tools::calc_angle(ball_pose, robot_pose));
+      const auto new_pose = trans_BtoR.inverted_transform(ROTATE_RADIUS, 0.0, -M_PI);
+
+      data_set.set_parsed_pose(new_pose);
+      data_set.set_parsed_dribble_power(DRIBBLE_RELEASE);
+
+      if (tools::is_same(robot_pose, new_pose, DISTANCE_THRESHOLD, THETA_THRESHOLD)) {
+        return ROTATE;
+      }
+
+      return APPROACH;
+    };
+
+
+  tactic_functions_[ROTATE] = [this](TacticDataSet & data_set) -> TacticName {
+      // ボールを中心にロボットが回転移動し、ボールと目標値の直線上に移動する
+      // 目的位置を背中に捉えたら、次の行動に移行する
+      constexpr auto DISTANCE_THRESHOLD = 0.05;  // meters
+      const auto THETA_THRESHOLD = tools::to_radians(5.0);
+      const auto OMEGA_THRESHOLD = 0.01;  // rad/s
+
+      const auto robot_pose = tools::pose_state(data_set.get_my_robot());
+      const auto ball_pose = tools::pose_state(data_set.get_ball());
+      const auto target_pose = data_set.get_target();
+
+      // ボールから目標位置を結ぶ直線上で、ロボットがボールを見ながら、ボールの周りを旋回する
+      const tools::Trans trans_BtoT(ball_pose, tools::calc_angle(ball_pose, target_pose));
+
+      const auto robot_pose_BtoT = trans_BtoT.transform(robot_pose);
+      const auto angle_robot_position = tools::calc_angle(State(), robot_pose_BtoT);
+
+      const auto ADD_ANGLE = tools::to_radians(15.0);
+
+      State new_pose;
+      if (std::fabs(angle_robot_position) < ADD_ANGLE) {
+        // ボールの裏に回ったら、直進する
+        new_pose = trans_BtoT.inverted_transform(ROBOT_RADIUS + BALL_RADIUS, 0.0, M_PI);
+      } else {
+        // ボールの周りを旋回する
+        const auto theta = angle_robot_position - std::copysign(ADD_ANGLE, angle_robot_position);
+        double pos_x = ROTATE_RADIUS * std::cos(theta);
+        double pos_y = ROTATE_RADIUS * std::sin(theta);
+        new_pose = trans_BtoT.inverted_transform(pos_x, pos_y, theta + M_PI);
+      }
+
+      data_set.set_parsed_pose(new_pose);
+      data_set.set_parsed_dribble_power(DRIBBLE_CATCH);
+
+      // ロボットが目標姿勢に近づき、回転速度が小さくなったら次の行動に移行
+      const auto robot_vel = tools::velocity_state(data_set.get_my_robot());
+      if (tools::is_same(robot_pose, new_pose, DISTANCE_THRESHOLD, THETA_THRESHOLD) &&
+        robot_vel.theta < OMEGA_THRESHOLD)
+      {
+        return CATCH;
+      }
+
+      return ROTATE;
+    };
+
+  tactic_functions_[CATCH] = [this](TacticDataSet & data_set) -> TacticName {
+      // ボールに向かって前進し、数秒待つ
+      constexpr double CATCH_TIME = 3.0;
+
+      const auto ball_pose = tools::pose_state(data_set.get_ball());
+      const auto target_pose = data_set.get_target();
+
+      // ボールから目標位置を結ぶ直線上で、ロボットがボールを見ながら、ボールの周りを旋回する
+      const tools::Trans trans_BtoT(ball_pose, tools::calc_angle(ball_pose, target_pose));
+
+      auto new_pose = trans_BtoT.inverted_transform(ROBOT_RADIUS + BALL_RADIUS, 0.0, M_PI);
+
+      data_set.set_parsed_pose(new_pose);
+      data_set.set_parsed_dribble_power(DRIBBLE_CATCH);
+
+
+      const auto elapsed =
+        std::chrono::system_clock::now() - tactic_time_.at(data_set.get_my_robot().robot_id.id);
+      if (elapsed > std::chrono::duration<double>(CATCH_TIME)) {
+        return CARRY;
+      }
+
+      return CATCH;
+    };
+
+  tactic_functions_[CARRY] = [this](TacticDataSet & data_set) -> TacticName {
+      // ボールが目的地に着くまで前進する
+      constexpr auto DISTANCE_THRESHOLD = 0.01;  // meters
+      const auto THETA_THRESHOLD = tools::to_radians(5.0);
+
+      const auto robot_pose = tools::pose_state(data_set.get_my_robot());
+      const auto target_pose = data_set.get_target();
+
+      // ボールが消えることを考慮して、ターゲットとロボットの座標系で目標位置を生成する
+      constexpr double MOVE_DISTANCE = 0.1;   // meters
+      constexpr double CAREFUL_DISTANCE = 0.5;  // meters
+      State new_pose;
+
+      if (tools::distance(robot_pose, target_pose) > CAREFUL_DISTANCE) {
+        const tools::Trans trans_RtoT(robot_pose, tools::calc_angle(robot_pose, target_pose));
+        new_pose = trans_RtoT.inverted_transform(MOVE_DISTANCE, 0.0, M_PI);
+      } else {
+        // target付近で暴れないように、targetを基準にした目標位置を生成する
+        const tools::Trans trans_TtoR(target_pose, tools::calc_angle(target_pose, robot_pose));
+        new_pose = trans_TtoR.inverted_transform(ROBOT_RADIUS, 0.0, 0.0);
+      }
+
+      data_set.set_parsed_pose(new_pose);
+      data_set.set_parsed_dribble_power(DRIBBLE_CATCH);
+
+      if (tools::is_same(robot_pose, new_pose, DISTANCE_THRESHOLD, THETA_THRESHOLD)) {
+        return RELEASE;
+      }
+
+      return CARRY;
+    };
+
+  tactic_functions_[RELEASE] = [this](TacticDataSet & data_set) -> TacticName {
+      // ドリブラーをオフし、その場にとどまる
+      const auto robot_pose = tools::pose_state(data_set.get_my_robot());
+      const auto target_pose = data_set.get_target();
+      const tools::Trans trans_TtoR(target_pose, tools::calc_angle(target_pose, robot_pose));
+      const auto new_pose = trans_TtoR.inverted_transform(ROBOT_RADIUS * 1.0, 0.0, -M_PI);
+      data_set.set_parsed_pose(new_pose);
+      data_set.set_parsed_dribble_power(DRIBBLE_RELEASE);
+
+
+      // ボールがtargetから大きく離れていたらリセット
+      const auto ball_pose = tools::pose_state(data_set.get_ball());
+      if (tools::distance(ball_pose, target_pose) > 0.05) {
+        return APPROACH;
+      }
+
+      return RELEASE;
+    };
+}
+
+bool BackDribbleTactics::update(
+  const State & dribble_target, const TrackedRobot & my_robot, const TrackedBall & ball,
+  State & parsed_pose, double & parsed_dribble_power)
+{
+  const auto robot_id = my_robot.robot_id.id;
+  // If the robot is not in the map, initialize the tactic state.
+  if (tactic_name_.find(robot_id) == tactic_name_.end()) {
+    tactic_name_[robot_id] = APPROACH;
+  }
+
+  // ロボットボールが大きく離れたらリセットする
+  if (tools::distance(tools::pose_state(my_robot), tools::pose_state(ball)) > 0.5) {
+    tactic_name_[robot_id] = APPROACH;
+  }
+
+  // Execute the tactic fuction.
+  TacticDataSet data_set(my_robot, ball, dribble_target, parsed_pose, 0.0, parsed_dribble_power);
+  const auto next_tactic = tactic_functions_[tactic_name_[robot_id]](data_set);
+
+  if (tactic_name_[robot_id] != next_tactic) {
+    // Reset timestamp
+    tactic_name_[robot_id] = next_tactic;
+    tactic_time_[robot_id] = chrono::system_clock::now();
+  }
+
+  parsed_pose = data_set.get_parsed_pose();
+  parsed_dribble_power = data_set.get_parsed_dribble_power();
+
+  return true;
+}
+
+}  // namespace back_dribble_tactics


### PR DESCRIPTION
バックドリブル機能を追加します。

これを用いて、ボールプレースメント時に、壁際のボールをドリブルで吸い出します。

## 懸念事項

シュート処理の影響により、ボール吸い出したあと、ドリブラーを回しながらくるくるロボットが動くことがあります。

別PRで直します。