### PR TITLE
fix: launchファイルの引数からロボットのカラー変更ができるように変更

### DIFF
--- a/consai_game/consai_game/main.py
+++ b/consai_game/consai_game/main.py
@@ -39,12 +39,14 @@ if __name__ == '__main__':
     arg_parser = argparse.ArgumentParser()
     PlayNode.add_arguments(arg_parser)
 
+    arg_parser.add_argument('--yellow', type=bool, default=False)
+
     args, other_args = arg_parser.parse_known_args()
     rclpy.init(args=other_args)
 
     play_node = PlayNode(update_hz=10, book_name=args.playbook)
-    # TODOL: team_is_yellowを引数から取得したい
-    team_is_yellow = False
+
+    team_is_yellow = args.yellow
     world_model_provider_node = WorldModelProviderNode(
         update_hz=10, team_is_yellow=team_is_yellow)
     # TODO: agent_numをplay_nodeから取得したい

--- a/consai_game/launch/start.launch
+++ b/consai_game/launch/start.launch
@@ -36,5 +36,5 @@
   <node pkg="consai_game"
         exec="main.py"
         output="screen"
-        args="--playbook $(find-pkg-share consai_game)/play/books/$(var playbook).py" />
+        args="--playbook $(find-pkg-share consai_game)/play/books/$(var playbook).py --yellow $(var yellow)" />
 </launch>


### PR DESCRIPTION
タイトル通り。

## 確認事項
- 昨日実装したレフェリーコマンド対応を使用して、引数から自チームをyellowに設定した状態でyellowに関係したレフェリー信号が発行された際にourと出力されるか確認