### PR TITLE
Refactor referee_model to use lock

### DIFF
--- a/consai_game/consai_game/world_model/referee_model.py
+++ b/consai_game/consai_game/world_model/referee_model.py
@@ -24,7 +24,7 @@ class RefereeModel:
         self.sub_referee = None
         self.current_command = Referee.COMMAND_HALT
 
-    def callback(self, msg: Referee):
+    def parse_msg(self, msg: Referee):
         self.current_command = msg.command
 
     @property

--- a/consai_game/consai_game/world_model/world_model_provider_node.py
+++ b/consai_game/consai_game/world_model/world_model_provider_node.py
@@ -35,9 +35,9 @@ class WorldModelProviderNode(Node):
 
         self.world_model = WorldModel()
         self.world_model.set_our_team_is_yellow(team_is_yellow)
-        self.world_model.referee.sub_referee = self.create_subscription(
-            Referee, 'referee', self.world_model.referee.callback, 10)
 
+        self.sub_referee = self.create_subscription(
+            Referee, 'referee', self.callback_referee, 10)
         self.sub_detection_traced = self.create_subscription(
             TrackedFrame, 'detection_tracked', self.callback_detection_traced, 10)
 
@@ -53,6 +53,10 @@ class WorldModelProviderNode(Node):
     def update(self) -> None:
         with self.lock:
             self.get_logger().debug(f'WorldModelProvider update, {process_info()}')
+
+    def callback_referee(self, msg: Referee) -> None:
+        with self.lock:
+            self.world_model.referee.parse_msg(msg)
 
     def callback_detection_traced(self, msg: TrackedFrame) -> None:
         with self.lock:


### PR DESCRIPTION
lockを使って安全にデータを更新できるようにreferee_model周りをリファクタリングします。

APIに変更はありません。