### PR TITLE
Add by_visible role assignment.

### DIFF
--- a/consai_game/consai_game/core/play/play_node.py
+++ b/consai_game/consai_game/core/play/play_node.py
@@ -18,7 +18,9 @@
 import argparse
 from consai_game.core.play.play import Play
 from consai_game.core.role_assignment.assignor import RoleAssignor
-from consai_game.core.role_assignment.factory import create_method as create_role_assignment_method
+from consai_game.core.role_assignment.factory import (
+    create_method as create_role_assignment_method,
+)
 from consai_game.core.role_assignment.factory import RoleAssignmentMethods
 from consai_game.core.tactic.role import Role
 from consai_game.utils.process_info import process_info
@@ -28,6 +30,7 @@ from pathlib import Path
 from rclpy.node import Node
 import threading
 from typing import Callable
+from typing import Optional
 
 
 UpdateRoleCallback = Callable[[list[Role]], None]
@@ -53,8 +56,10 @@ class PlayNode(Node):
     @classmethod
     def add_arguments(cls, parser: argparse.ArgumentParser):
         parser.add_argument(
-            "--playbook", default="", type=str,
-            help="Set playbook file path (e.g.: path/to/playbook.py)"
+            "--playbook",
+            default="",
+            type=str,
+            help="Set playbook file path (e.g.: path/to/playbook.py)",
         )
         parser.add_argument(
             "--assign",
@@ -87,8 +92,7 @@ class PlayNode(Node):
 
     def select_role_assignment_method(self, name: str):
         with self.lock:
-            self.role_assignor = RoleAssignor(
-                create_role_assignment_method(name))
+            self.role_assignor = RoleAssignor(create_role_assignment_method(name))
 
             if self.role_assignor is None:
                 text = "Role assignment method is not set"
@@ -101,6 +105,9 @@ class PlayNode(Node):
 
             if self.current_play is None:
                 self.current_play = self.select_play()
+                if self.current_play is None:
+                    return
+
                 self.update_role()
                 self.get_logger().info(f"Selected play: {self.current_play.name}")
 
@@ -108,15 +115,14 @@ class PlayNode(Node):
 
             self.evaluate_play()
 
-    def select_play(self) -> Play:
+    def select_play(self) -> Optional[Play]:
         applicable_plays = [
-            play
-            for play in self.playbook
-            if play.is_applicable(self.world_model)
+            play for play in self.playbook if play.is_applicable(self.world_model)
         ]
 
         if not applicable_plays:
-            raise ValueError("No applicable plays found")
+            self.get_logger().warn("No applicable plays found")
+            return None
 
         # TODO: 評価関数を実装して選択する
         return applicable_plays[0]
@@ -135,18 +141,21 @@ class PlayNode(Node):
         visible_robots_num = len(self.world_model.robot_activity.our_visible_robots)
         if self.our_robots_num != visible_robots_num:
             self.our_robots_num = visible_robots_num
-            self.get_logger().info(f"Robots num changed. Play aborted: {self.current_play.name}")
+            self.get_logger().info(
+                f"Robots num changed. Play aborted: {self.current_play.name}"
+            )
             self.current_play = None
 
     def update_role(self):
         # Role(tacticとrobot_id)を更新し、callback関数にセットする
         assigned_ids = self.role_assignor.assign(
-            self.current_play.roles, self.world_model)
+            self.current_play.roles, self.world_model
+        )
 
         roles = []
         for i in range(len(self.current_play.roles)):
-            roles.append(Role(
-                tactics=self.current_play.roles[i],
-                robot_id=assigned_ids[i]))
+            roles.append(
+                Role(tactics=self.current_play.roles[i], robot_id=assigned_ids[i])
+            )
 
         self.update_role_callback(roles)

--- a/consai_game/consai_game/core/role_assignment/factory.py
+++ b/consai_game/consai_game/core/role_assignment/factory.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from consai_game.core.role_assignment.methods.by_id import ByIDMethod
+from consai_game.core.role_assignment.methods.by_visible import ByVisible
 from enum import Enum
 
 
@@ -20,10 +21,14 @@ class RoleAssignmentMethods(Enum):
     """役割割り当ての方法を列挙する."""
 
     BY_ID = "by_id"
+    BY_VISIBLE = "by_visible"
 
 
 def create_method(name: str):
     """役割割り当ての方法を生成する."""
     if name == RoleAssignmentMethods.BY_ID.value:
         return ByIDMethod()
+    elif name == RoleAssignmentMethods.BY_VISIBLE.value:
+        return ByVisible()
+
     raise ValueError(f"Unknown role assignment method: {name}")

--- a/consai_game/consai_game/core/role_assignment/methods/by_visible.py
+++ b/consai_game/consai_game/core/role_assignment/methods/by_visible.py
@@ -1,0 +1,35 @@
+# Copyright 2025 Roots
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from consai_game.core.role_assignment.methods.base import RoleAssignmentBase
+from consai_game.core.tactic.role import RoleConst
+from consai_game.core.tactic.tactic_base import TacticBase
+from consai_game.world_model.world_model import WorldModel
+from typing import List
+
+
+class ByVisible(RoleAssignmentBase):
+    """フィールドに現れた順にRoleを割り当てる."""
+
+    def assign(
+        self, play_roles: List[List[TacticBase]], world_model: WorldModel
+    ) -> List[int]:
+        # ロールの数だけ、ロボットIDを取得する
+        id_list = world_model.robot_activity.ordered_our_visible_robots[
+            : len(play_roles)
+        ]
+
+        # ロボットの数がロールより少ない場合、INVALID_ROLE_IDで埋める
+        id_list += [RoleConst.INVALID_ROLE_ID] * (len(play_roles) - len(id_list))
+        return id_list

--- a/consai_game/launch/start.launch
+++ b/consai_game/launch/start.launch
@@ -32,7 +32,8 @@
   </node_container>
 
   <arg name="playbook" default="playbook_default" description='Set a playbook file name from the play/books directory.'/>
-  <arg name="assign" default="by_id" description='Select a role_assignment method'/>
+  <arg name="assign" default="by_visible"
+    description='Select a role_assignment method from {by_id, by_visible}'/>
 
   <set_env name="PYTHONUNBUFFERED" value="1" />
 


### PR DESCRIPTION

フィールドに現れた順にロールアサインする`by_visible`メソッドを追加します。

先頭のロールを優先的に　かつ　ロールの交代が最小限になるように割り当てます。

また、STOPゲーム中にconsaiを起動するとplayが見つからずにエラーが出る場合があります。
対策としてapplicableなplayがなくても例外が発生しないようにしました。


## 確認方法

ロボットのON/OFFを繰り返し、エラーなくロボットがアサインされることを確認しました。
