### PR TITLE
python関係のpre-commitについて，行の長さを120文字までに変更

### DIFF
--- a/consai_game/CMakeLists.txt
+++ b/consai_game/CMakeLists.txt
@@ -27,10 +27,14 @@ install(DIRECTORY
 )
 
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  set(ament_cmake_copyright_FOUND TRUE)
-  set(ament_cmake_cpplint_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
+  # find_package(ament_lint_auto REQUIRED)
+  # set(ament_cmake_copyright_FOUND TRUE)
+  # set(ament_cmake_cpplint_FOUND TRUE)
+  # ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_flake8 REQUIRED)
+  ament_flake8(
+    CONFIG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../setup.cfg
+  ) 
 endif()
 
 ament_package()

--- a/hooks/run_ament_black.sh
+++ b/hooks/run_ament_black.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+# プロジェクトルートへ移動
+cd "$(git rev-parse --show-toplevel)"
+
+FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$' || true)
+
+if [ -z "$FILES" ]; then
+  echo "[ament_black] No Python files to format."
+  exit 0
+fi
+
+echo "[ament_black] Formatting files:"
+echo "$FILES"
+
+ament_black --reformat --config pyproject.toml $FILES

--- a/hooks/run_ament_flake8.sh
+++ b/hooks/run_ament_flake8.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 set -e
 
-# Pythonファイルを渡されたものだけに絞る
-FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$' || true)
-[ -z "$FILES" ] && exit 0
+# プロジェクトルートへ移動（どこから実行されても .cfg が見えるように）
+cd "$(git rev-parse --show-toplevel)"
 
-ament_flake8 $FILES
+# ステージ済みの Python ファイルのみ取得
+FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$' || true)
+
+if [ -z "$FILES" ]; then
+  echo "[ament_flake8] No Python files to check."
+  exit 0
+fi
+
+echo "[ament_flake8] Running on files:"
+echo "$FILES"
+
+# 設定ファイル (setup.cfg or tox.ini) を自動検出し、flake8 を実行
+ament_flake8 --config setup.cfg $FILES

--- a/hooks/run_ament_pep257.sh
+++ b/hooks/run_ament_pep257.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 set -e
 
+# プロジェクトルートへ移動（設定ファイルが見えるように）
+cd "$(git rev-parse --show-toplevel)"
+
+# ステージ済みの Python ファイルのみ取得
 FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$' || true)
-[ -z "$FILES" ] && exit 0
 
+if [ -z "$FILES" ]; then
+  echo "[ament_pep257] No Python files to check."
+  exit 0
+fi
+
+echo "[ament_pep257] Running on files:"
+echo "$FILES"
+
+# 設定ファイル（setup.cfg など）を使って ament_pep257 を実行
 ament_pep257 $FILES
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
設定ファイルを設置
- setup.cfg
- pyproject.toml

hookのファイルも設定ファイルを読めるように変更