### PR TITLE
フィールドの半分の長さをメンバ変数として用意

### DIFF
--- a/consai_game/consai_game/world_model/ball_position_model.py
+++ b/consai_game/consai_game/world_model/ball_position_model.py
@@ -36,10 +36,6 @@ class BallPositionModel:
         """インスタンス生成時の初期化."""
         self._pos = State2D()
         self._field = field
-        self._field_half_length = self._field.length / 2
-        self._field_half_width = self._field.width / 2
-        self._field_half_penalty_depth = self._field.penalty_depth / 2
-        self._field_half_penalty_width = self._field.penalty_width / 2
         self._field_points = field_points
         self._outside_margin = 0.05  # フィールド外判定のマージン(m)
         self._hysteresis = 0.02  # ヒステリシスの閾値(m)
@@ -60,60 +56,57 @@ class BallPositionModel:
 
     def is_outside_of_left(self) -> bool:
         """ボールが左側のフィールド外にあるか判定する.ヒステリシス付き."""
-        current_pos_state = self._pos.x < -self._field_half_length
+        current_pos_state = self._pos.x < -self._field.half_length
         if current_pos_state != self._last_left_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 外に出た
-                current_pos_state = self._pos.x < -self._field_half_length - self._hysteresis
+                current_pos_state = self._pos.x < -self._field.half_length - self._hysteresis
             else:
                 # 内に入った
-                current_pos_state = self._pos.x < -self._field_half_length + self._hysteresis
+                current_pos_state = self._pos.x < -self._field.half_length + self._hysteresis
         self._last_left_state = current_pos_state
         return current_pos_state
 
     def is_outside_of_right(self) -> bool:
         """ボールが右側のフィールド外にあるか判定する.ヒステリシス付き."""
-        # current_pos_state = self._pos.x > self._field.length / 2
-        current_pos_state = self._pos.x > self._field_half_length
+        current_pos_state = self._pos.x > self._field.half_length
         if current_pos_state != self._last_right_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 外に出た
-                current_pos_state = self._pos.x > self._field_half_length + self._hysteresis
+                current_pos_state = self._pos.x > self._field.half_length + self._hysteresis
             else:
                 # 内に入った
-                current_pos_state = self._pos.x > self._field_half_length - self._hysteresis
+                current_pos_state = self._pos.x > self._field.half_length - self._hysteresis
         self._last_right_state = current_pos_state
         return current_pos_state
 
     def is_outside_of_top(self) -> bool:
         """ボールが上側のフィールド外にあるか判定する.ヒステリシス付き."""
-        # current_pos_state = self._pos.y > self._field.width / 2
-        current_pos_state = self._pos.y > self._field_half_width
+        current_pos_state = self._pos.y > self._field.half_width
         if current_pos_state != self._last_top_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 外に出た
-                current_pos_state = self._pos.y > self._field_half_width + self._hysteresis
+                current_pos_state = self._pos.y > self._field.half_width + self._hysteresis
             else:
                 # 内に入った
-                current_pos_state = self._pos.y > self._field_half_width - self._hysteresis
+                current_pos_state = self._pos.y > self._field.half_width - self._hysteresis
         self._last_top_state = current_pos_state
         return current_pos_state
 
     def is_outside_of_bottom(self) -> bool:
         """ボールが下側のフィールド外にあるか判定する.ヒステリシス付き."""
-        # current_pos_state = self._pos.y < -self._field.width / 2
-        current_pos_state = self._pos.y < -self._field_half_width
+        current_pos_state = self._pos.y < -self._field.half_width
         if current_pos_state != self._last_bottom_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 外に出た
-                current_pos_state = self._pos.y < -self._field_half_width - self._hysteresis
+                current_pos_state = self._pos.y < -self._field.half_width - self._hysteresis
             else:
                 # 内に入った
-                current_pos_state = self._pos.y < -self._field_half_width + self._hysteresis
+                current_pos_state = self._pos.y < -self._field.half_width + self._hysteresis
         self._last_bottom_state = current_pos_state
         return current_pos_state
 
@@ -128,57 +121,57 @@ class BallPositionModel:
 
     def is_outside_of_left_with_margin(self) -> bool:
         """マージンを考慮して、ボールが左側のフィールド外にあるか判定する.ヒステリシス付き."""
-        current_pos_state = self._pos.x < -self._field_half_length - self._outside_margin
+        current_pos_state = self._pos.x < -self._field.half_length - self._outside_margin
         if current_pos_state != self._last_left_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 外に出た
-                current_pos_state = self._pos.x < -self._field_half_length - self._outside_margin - self._hysteresis
+                current_pos_state = self._pos.x < -self._field.half_length - self._outside_margin - self._hysteresis
             else:
                 # 内に入った
-                current_pos_state = self._pos.x < -self._field_half_length - self._outside_margin + self._hysteresis
+                current_pos_state = self._pos.x < -self._field.half_length - self._outside_margin + self._hysteresis
         self._last_left_state = current_pos_state
         return current_pos_state
 
     def is_outside_of_right_with_margin(self) -> bool:
         """マージンを考慮して、ボールが右側のフィールド外にあるか判定する.ヒステリシス付き."""
-        current_pos_state = self._pos.x > self._field_half_length + self._outside_margin
+        current_pos_state = self._pos.x > self._field.half_length + self._outside_margin
         if current_pos_state != self._last_right_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 外に出た
-                current_pos_state = self._pos.x > self._field_half_length + self._outside_margin + self._hysteresis
+                current_pos_state = self._pos.x > self._field.half_length + self._outside_margin + self._hysteresis
             else:
                 # 内に入った
-                current_pos_state = self._pos.x > self._field_half_length + self._outside_margin - self._hysteresis
+                current_pos_state = self._pos.x > self._field.half_length + self._outside_margin - self._hysteresis
         self._last_right_state = current_pos_state
         return current_pos_state
 
     def is_outside_of_top_with_margin(self) -> bool:
         """マージンを考慮して、ボールが上側のフィールド外にあるか判定する.ヒステリシス付き."""
-        current_pos_state = self._pos.y > self._field_half_width + self._outside_margin
+        current_pos_state = self._pos.y > self._field.half_width + self._outside_margin
         if current_pos_state != self._last_top_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 外に出た
-                current_pos_state = self._pos.y > self._field_half_width + self._outside_margin + self._hysteresis
+                current_pos_state = self._pos.y > self._field.half_width + self._outside_margin + self._hysteresis
             else:
                 # 内に入った
-                current_pos_state = self._pos.y > self._field_half_width + self._outside_margin - self._hysteresis
+                current_pos_state = self._pos.y > self._field.half_width + self._outside_margin - self._hysteresis
         self._last_top_state = current_pos_state
         return current_pos_state
 
     def is_outside_of_bottom_with_margin(self) -> bool:
         """マージンを考慮して、ボールが下側のフィールド外にあるか判定する.ヒステリシス付き."""
-        current_pos_state = self._pos.y < -self._field_half_width - self._outside_margin
+        current_pos_state = self._pos.y < -self._field.half_width - self._outside_margin
         if current_pos_state != self._last_bottom_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 外に出た
-                current_pos_state = self._pos.y < -self._field_half_width - self._outside_margin - self._hysteresis
+                current_pos_state = self._pos.y < -self._field.half_width - self._outside_margin - self._hysteresis
             else:
                 # 内に入った
-                current_pos_state = self._pos.y < -self._field_half_width - self._outside_margin + self._hysteresis
+                current_pos_state = self._pos.y < -self._field.half_width - self._outside_margin + self._hysteresis
         self._last_bottom_state = current_pos_state
         return current_pos_state
 
@@ -194,22 +187,22 @@ class BallPositionModel:
     def is_in_our_defense_area(self) -> bool:
         """ボールが自チームのディフェンスエリア内にあるか判定する.ヒステリシス付き."""
         current_pos_state = (
-            math.fabs(self._pos.y) < self._field_half_penalty_width
-            and self._pos.x < -self._field_half_length + self._field.penalty_depth
+            math.fabs(self._pos.y) < self._field.half_penalty_width
+            and self._pos.x < -self._field.half_length + self._field.penalty_depth
         )
         if current_pos_state != self._last_our_defense_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 内に入った
                 current_pos_state = (
-                    math.fabs(self._pos.y) < self._field_half_penalty_width - self._hysteresis
-                    and self._pos.x < -self._field_half_length + self._field.penalty_depth - self._hysteresis
+                    math.fabs(self._pos.y) < self._field.half_penalty_width - self._hysteresis
+                    and self._pos.x < -self._field.half_length + self._field.penalty_depth - self._hysteresis
                 )
             else:
                 # 外に出た
                 current_pos_state = (
-                    math.fabs(self._pos.y) < self._field_half_penalty_width + self._hysteresis
-                    and self._pos.x < -self._field_half_length + self._field.penalty_depth + self._hysteresis
+                    math.fabs(self._pos.y) < self._field.half_penalty_width + self._hysteresis
+                    and self._pos.x < -self._field.half_length + self._field.penalty_depth + self._hysteresis
                 )
         self._last_our_defense_state = current_pos_state
         return current_pos_state
@@ -217,22 +210,22 @@ class BallPositionModel:
     def is_in_their_defense_area(self) -> bool:
         """ボールが相手チームのディフェンスエリア内にあるか判定する.ヒステリシス付き."""
         current_pos_state = (
-            math.fabs(self._pos.y) < self._field_half_penalty_width
-            and self._pos.x > self._field_half_length - self._field.penalty_depth
+            math.fabs(self._pos.y) < self._field.half_penalty_width
+            and self._pos.x > self._field.half_length - self._field.penalty_depth
         )
         if current_pos_state != self._last_their_defense_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 内に入った
                 current_pos_state = (
-                    math.fabs(self._pos.y) < self._field_half_penalty_width - self._hysteresis
-                    and self._pos.x > self._field_half_length - self._field.penalty_depth + self._hysteresis
+                    math.fabs(self._pos.y) < self._field.half_penalty_width - self._hysteresis
+                    and self._pos.x > self._field.half_length - self._field.penalty_depth + self._hysteresis
                 )
             else:
                 # 外に出た
                 current_pos_state = (
-                    math.fabs(self._pos.y) < self._field_half_penalty_width + self._hysteresis
-                    and self._pos.x > self._field_half_length - self._field.penalty_depth - self._hysteresis
+                    math.fabs(self._pos.y) < self._field.half_penalty_width + self._hysteresis
+                    and self._pos.x > self._field.half_length - self._field.penalty_depth - self._hysteresis
                 )
         self._last_their_defense_state = current_pos_state
         return current_pos_state

--- a/consai_game/consai_game/world_model/ball_position_model.py
+++ b/consai_game/consai_game/world_model/ball_position_model.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 # coding: UTF-8
 
+"""
+ボールの位置情報を管理するためのクラスを提供する.
+
+ボールの位置更新, フィールド境界の判定（ヒステリシス付き）, および各エリア内かどうかの判定をする.
+"""
+
 # Copyright 2025 Roots
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,18 +21,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from consai_msgs.msg import State2D
-from consai_game.world_model.field_model import Field, FieldPoints
-from consai_game.world_model.ball_model import BallModel
 import math
+
+from consai_game.world_model.ball_model import BallModel
+from consai_game.world_model.field_model import Field, FieldPoints
+
+from consai_msgs.msg import State2D
 
 
 class BallPositionModel:
     """ボールの位置情報を管理するクラス."""
 
     def __init__(self, field: Field, field_points: FieldPoints):
+        """インスタンス生成時の初期化."""
         self._pos = State2D()
         self._field = field
+        self._field_half_length = self._field.length / 2
+        self._field_half_width = self._field.width / 2
+        self._field_half_penalty_depth = self._field.penalty_depth / 2
+        self._field_half_penalty_width = self._field.penalty_width / 2
         self._field_points = field_points
         self._outside_margin = 0.05  # フィールド外判定のマージン(m)
         self._hysteresis = 0.02  # ヒステリシスの閾値(m)
@@ -39,9 +52,7 @@ class BallPositionModel:
         self._last_our_side_state = False  # 前回の自チームサイド判定状態
         self._last_their_side_state = False  # 前回の相手チームサイド判定状態
 
-    def update_position(
-        self, ball_model: BallModel, field_model: Field, field_points: FieldPoints
-    ) -> None:
+    def update_position(self, ball_model: BallModel, field_model: Field, field_points: FieldPoints) -> None:
         """ボールの位置を更新する."""
         self._pos = ball_model.pos
         self._field = field_model
@@ -49,73 +60,60 @@ class BallPositionModel:
 
     def is_outside_of_left(self) -> bool:
         """ボールが左側のフィールド外にあるか判定する.ヒステリシス付き."""
-        current_pos_state = self._pos.x < -self._field.length / 2
+        current_pos_state = self._pos.x < -self._field_half_length
         if current_pos_state != self._last_left_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 外に出た
-                current_pos_state = (
-                    self._pos.x < -self._field.length / 2 - self._hysteresis
-                )
+                current_pos_state = self._pos.x < -self._field_half_length - self._hysteresis
             else:
                 # 内に入った
-                current_pos_state = (
-                    self._pos.x < -self._field.length / 2 + self._hysteresis
-                )
+                current_pos_state = self._pos.x < -self._field_half_length + self._hysteresis
         self._last_left_state = current_pos_state
         return current_pos_state
 
     def is_outside_of_right(self) -> bool:
         """ボールが右側のフィールド外にあるか判定する.ヒステリシス付き."""
-        current_pos_state = self._pos.x > self._field.length / 2
+        # current_pos_state = self._pos.x > self._field.length / 2
+        current_pos_state = self._pos.x > self._field_half_length
         if current_pos_state != self._last_right_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 外に出た
-                current_pos_state = (
-                    self._pos.x > self._field.length / 2 + self._hysteresis
-                )
+                current_pos_state = self._pos.x > self._field_half_length + self._hysteresis
             else:
                 # 内に入った
-                current_pos_state = (
-                    self._pos.x > self._field.length / 2 - self._hysteresis
-                )
+                current_pos_state = self._pos.x > self._field_half_length - self._hysteresis
         self._last_right_state = current_pos_state
         return current_pos_state
 
     def is_outside_of_top(self) -> bool:
         """ボールが上側のフィールド外にあるか判定する.ヒステリシス付き."""
-        current_pos_state = self._pos.y > self._field.width / 2
+        # current_pos_state = self._pos.y > self._field.width / 2
+        current_pos_state = self._pos.y > self._field_half_width
         if current_pos_state != self._last_top_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 外に出た
-                current_pos_state = (
-                    self._pos.y > self._field.width / 2 + self._hysteresis
-                )
+                current_pos_state = self._pos.y > self._field_half_width + self._hysteresis
             else:
                 # 内に入った
-                current_pos_state = (
-                    self._pos.y > self._field.width / 2 - self._hysteresis
-                )
+                current_pos_state = self._pos.y > self._field_half_width - self._hysteresis
         self._last_top_state = current_pos_state
         return current_pos_state
 
     def is_outside_of_bottom(self) -> bool:
         """ボールが下側のフィールド外にあるか判定する.ヒステリシス付き."""
-        current_pos_state = self._pos.y < -self._field.width / 2
+        # current_pos_state = self._pos.y < -self._field.width / 2
+        current_pos_state = self._pos.y < -self._field_half_width
         if current_pos_state != self._last_bottom_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 外に出た
-                current_pos_state = (
-                    self._pos.y < -self._field.width / 2 - self._hysteresis
-                )
+                current_pos_state = self._pos.y < -self._field_half_width - self._hysteresis
             else:
                 # 内に入った
-                current_pos_state = (
-                    self._pos.y < -self._field.width / 2 + self._hysteresis
-                )
+                current_pos_state = self._pos.y < -self._field_half_width + self._hysteresis
         self._last_bottom_state = current_pos_state
         return current_pos_state
 
@@ -130,81 +128,57 @@ class BallPositionModel:
 
     def is_outside_of_left_with_margin(self) -> bool:
         """マージンを考慮して、ボールが左側のフィールド外にあるか判定する.ヒステリシス付き."""
-        current_pos_state = self._pos.x < -self._field.length / 2 - self._outside_margin
+        current_pos_state = self._pos.x < -self._field_half_length - self._outside_margin
         if current_pos_state != self._last_left_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 外に出た
-                current_pos_state = (
-                    self._pos.x
-                    < -self._field.length / 2 - self._outside_margin - self._hysteresis
-                )
+                current_pos_state = self._pos.x < -self._field_half_length - self._outside_margin - self._hysteresis
             else:
                 # 内に入った
-                current_pos_state = (
-                    self._pos.x
-                    < -self._field.length / 2 - self._outside_margin + self._hysteresis
-                )
+                current_pos_state = self._pos.x < -self._field_half_length - self._outside_margin + self._hysteresis
         self._last_left_state = current_pos_state
         return current_pos_state
 
     def is_outside_of_right_with_margin(self) -> bool:
         """マージンを考慮して、ボールが右側のフィールド外にあるか判定する.ヒステリシス付き."""
-        current_pos_state = self._pos.x > self._field.length / 2 + self._outside_margin
+        current_pos_state = self._pos.x > self._field_half_length + self._outside_margin
         if current_pos_state != self._last_right_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 外に出た
-                current_pos_state = (
-                    self._pos.x
-                    > self._field.length / 2 + self._outside_margin + self._hysteresis
-                )
+                current_pos_state = self._pos.x > self._field_half_length + self._outside_margin + self._hysteresis
             else:
                 # 内に入った
-                current_pos_state = (
-                    self._pos.x
-                    > self._field.length / 2 + self._outside_margin - self._hysteresis
-                )
+                current_pos_state = self._pos.x > self._field_half_length + self._outside_margin - self._hysteresis
         self._last_right_state = current_pos_state
         return current_pos_state
 
     def is_outside_of_top_with_margin(self) -> bool:
         """マージンを考慮して、ボールが上側のフィールド外にあるか判定する.ヒステリシス付き."""
-        current_pos_state = self._pos.y > self._field.width / 2 + self._outside_margin
+        current_pos_state = self._pos.y > self._field_half_width + self._outside_margin
         if current_pos_state != self._last_top_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 外に出た
-                current_pos_state = (
-                    self._pos.y
-                    > self._field.width / 2 + self._outside_margin + self._hysteresis
-                )
+                current_pos_state = self._pos.y > self._field_half_width + self._outside_margin + self._hysteresis
             else:
                 # 内に入った
-                current_pos_state = (
-                    self._pos.y
-                    > self._field.width / 2 + self._outside_margin - self._hysteresis
-                )
+                current_pos_state = self._pos.y > self._field_half_width + self._outside_margin - self._hysteresis
         self._last_top_state = current_pos_state
         return current_pos_state
 
     def is_outside_of_bottom_with_margin(self) -> bool:
         """マージンを考慮して、ボールが下側のフィールド外にあるか判定する.ヒステリシス付き."""
-        current_pos_state = self._pos.y < -self._field.width / 2 - self._outside_margin
+        current_pos_state = self._pos.y < -self._field_half_width - self._outside_margin
         if current_pos_state != self._last_bottom_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 外に出た
-                current_pos_state = (
-                    self._pos.y
-                    < -self._field.width / 2 - self._outside_margin - self._hysteresis
-                )
+                current_pos_state = self._pos.y < -self._field_half_width - self._outside_margin - self._hysteresis
             else:
                 # 内に入った
-                current_pos_state = (
-                    self._pos.y
-                    < -self._field.width / 2 - self._outside_margin + self._hysteresis
-                )
+                current_pos_state = self._pos.y < -self._field_half_width - self._outside_margin + self._hysteresis
         self._last_bottom_state = current_pos_state
         return current_pos_state
 
@@ -220,30 +194,22 @@ class BallPositionModel:
     def is_in_our_defense_area(self) -> bool:
         """ボールが自チームのディフェンスエリア内にあるか判定する.ヒステリシス付き."""
         current_pos_state = (
-            math.fabs(self._pos.y) < self._field.penalty_width / 2
-            and self._pos.x < -self._field.length / 2 + self._field.penalty_depth
+            math.fabs(self._pos.y) < self._field_half_penalty_width
+            and self._pos.x < -self._field_half_length + self._field.penalty_depth
         )
         if current_pos_state != self._last_our_defense_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 内に入った
                 current_pos_state = (
-                    math.fabs(self._pos.y)
-                    < self._field.penalty_width / 2 - self._hysteresis
-                    and self._pos.x
-                    < -self._field.length / 2
-                    + self._field.penalty_depth
-                    - self._hysteresis
+                    math.fabs(self._pos.y) < self._field_half_penalty_width - self._hysteresis
+                    and self._pos.x < -self._field_half_length + self._field.penalty_depth - self._hysteresis
                 )
             else:
                 # 外に出た
                 current_pos_state = (
-                    math.fabs(self._pos.y)
-                    < self._field.penalty_width / 2 + self._hysteresis
-                    and self._pos.x
-                    < -self._field.length / 2
-                    + self._field.penalty_depth
-                    + self._hysteresis
+                    math.fabs(self._pos.y) < self._field_half_penalty_width + self._hysteresis
+                    and self._pos.x < -self._field_half_length + self._field.penalty_depth + self._hysteresis
                 )
         self._last_our_defense_state = current_pos_state
         return current_pos_state
@@ -251,30 +217,22 @@ class BallPositionModel:
     def is_in_their_defense_area(self) -> bool:
         """ボールが相手チームのディフェンスエリア内にあるか判定する.ヒステリシス付き."""
         current_pos_state = (
-            math.fabs(self._pos.y) < self._field.penalty_width / 2
-            and self._pos.x > self._field.length / 2 - self._field.penalty_depth
+            math.fabs(self._pos.y) < self._field_half_penalty_width
+            and self._pos.x > self._field_half_length - self._field.penalty_depth
         )
         if current_pos_state != self._last_their_defense_state:
             # 状態が変化する場合、ヒステリシスを考慮
             if current_pos_state:
                 # 内に入った
                 current_pos_state = (
-                    math.fabs(self._pos.y)
-                    < self._field.penalty_width / 2 - self._hysteresis
-                    and self._pos.x
-                    > self._field.length / 2
-                    - self._field.penalty_depth
-                    + self._hysteresis
+                    math.fabs(self._pos.y) < self._field_half_penalty_width - self._hysteresis
+                    and self._pos.x > self._field_half_length - self._field.penalty_depth + self._hysteresis
                 )
             else:
                 # 外に出た
                 current_pos_state = (
-                    math.fabs(self._pos.y)
-                    < self._field.penalty_width / 2 + self._hysteresis
-                    and self._pos.x
-                    > self._field.length / 2
-                    - self._field.penalty_depth
-                    - self._hysteresis
+                    math.fabs(self._pos.y) < self._field_half_penalty_width + self._hysteresis
+                    and self._pos.x > self._field_half_length - self._field.penalty_depth - self._hysteresis
                 )
         self._last_their_defense_state = current_pos_state
         return current_pos_state

--- a/consai_game/consai_game/world_model/field_model.py
+++ b/consai_game/consai_game/world_model/field_model.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 # coding: UTF-8
 
+"""
+フィールドの寸法およびフィールド上の各ポイントを定義するクラスを提供する.
+
+各クラスはフィールドの基本情報（長さ・幅・ゴールの大きさ）やフィールド上の重要な座標を保持・生成する.
+"""
+
 # Copyright 2025 Roots
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,9 +22,9 @@
 # limitations under the License.
 
 
-from consai_game.utils.geometry import Point, Rectangle
-
 from dataclasses import dataclass
+
+from consai_game.utils.geometry import Point, Rectangle
 
 
 @dataclass
@@ -30,6 +36,12 @@ class Field:
     goal_width: float = 1.8
     penalty_depth: float = 1.8
     penalty_width: float = 3.6
+
+    half_length = length / 2
+    half_width = width / 2
+    half_goal_width = goal_width / 2
+    half_penalty_depth = penalty_depth / 2
+    half_penalty_width = penalty_width / 2
 
 
 @dataclass
@@ -46,7 +58,7 @@ class FieldPoints:
     their_defense_area: Rectangle
 
     @staticmethod
-    def create_field_points(field: Field) -> 'FieldPoints':
+    def create_field_points(field: Field) -> "FieldPoints":
         """フィールドの各ポイントを生成するメソッド."""
         center = Point(0.0, 0.0)
 
@@ -63,7 +75,7 @@ class FieldPoints:
             top_left=Point(-half_length, half_width),
             top_right=Point(half_length, half_width),
             bottom_left=Point(-half_length, -half_width),
-            bottom_right=Point(half_length, -half_width)
+            bottom_right=Point(half_length, -half_width),
         )
 
         half_penalty_width = field.penalty_width / 2
@@ -73,19 +85,21 @@ class FieldPoints:
             top_left=Point(-defense_area_length_outside, half_penalty_width),
             top_right=Point(-defense_area_length_inside, half_penalty_width),
             bottom_left=Point(-defense_area_length_outside, -half_penalty_width),
-            bottom_right=Point(-defense_area_length_inside, -half_penalty_width)
+            bottom_right=Point(-defense_area_length_inside, -half_penalty_width),
         )
         their_defense_area = Rectangle(
             top_left=Point(defense_area_length_inside, half_penalty_width),
             top_right=Point(defense_area_length_outside, half_penalty_width),
             bottom_left=Point(defense_area_length_inside, -half_penalty_width),
-            bottom_right=Point(defense_area_length_outside, -half_penalty_width)
+            bottom_right=Point(defense_area_length_outside, -half_penalty_width),
         )
-        return FieldPoints(center=center,
-                           our_goal_top=our_goal_top,
-                           our_goal_bottom=our_goal_bottom,
-                           their_goal_top=their_goal_top,
-                           their_goal_bottom=their_goal_bottom,
-                           corners=corners,
-                           our_defense_area=our_defense_area,
-                           their_defense_area=their_defense_area)
+        return FieldPoints(
+            center=center,
+            our_goal_top=our_goal_top,
+            our_goal_bottom=our_goal_bottom,
+            their_goal_top=their_goal_top,
+            their_goal_bottom=their_goal_bottom,
+            corners=corners,
+            our_defense_area=our_defense_area,
+            their_defense_area=their_defense_area,
+        )

--- a/consai_game/consai_game/world_model/world_model_provider_node.py
+++ b/consai_game/consai_game/world_model/world_model_provider_node.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
 # coding: UTF-8
 
+"""
+WorldModelProviderNode モジュール.
+
+このモジュールは ROS2 ノードとして動作する.
+Referee メッセージや TrackedFrame を受け取り, ワールドモデルをリアルタイムに更新する.
+"""
+
 # Copyright 2025 Roots
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,68 +22,97 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import threading
+
 from consai_game.utils.process_info import process_info
 from consai_game.world_model.world_model import WorldModel
-import json
+
 from rclpy.node import Node
-from rclpy.qos import QoSProfile, ReliabilityPolicy, DurabilityPolicy
+from rclpy.qos import DurabilityPolicy
+from rclpy.qos import QoSProfile
+from rclpy.qos import ReliabilityPolicy
+
 from robocup_ssl_msgs.msg import Referee
 from robocup_ssl_msgs.msg import TrackedFrame
+
 from std_msgs.msg import String
-import threading
 
 
 class WorldModelProviderNode(Node):
+    """
+    WorldModelの状態を他ノードに提供するための ROS2 ノード.
+
+    Referee や TrackedFrame メッセージを受け取り WorldModel を更新する.
+    consai_param/rule トピックからフィールド設定を受信し, フィールド寸法と関連情報を更新する.
+    """
+
     def __init__(self, update_hz: float = 10, team_is_yellow: bool = False):
-        super().__init__('world_model_provider_node')
+        """
+        初期化.
+
+        WorldModelProviderNode を初期化する.
+        """
+        super().__init__("world_model_provider_node")
         self.lock = threading.Lock()
 
-        self.timer = self.create_timer(1.0/update_hz, self.update)
+        self.timer = self.create_timer(1.0 / update_hz, self.update)
 
         self.world_model = WorldModel()
         self.world_model.set_our_team_is_yellow(team_is_yellow)
 
-        self.sub_referee = self.create_subscription(
-            Referee, 'referee', self.callback_referee, 10)
+        self.sub_referee = self.create_subscription(Referee, "referee", self.callback_referee, 10)
         self.sub_detection_traced = self.create_subscription(
-            TrackedFrame, 'detection_tracked', self.callback_detection_traced, 10)
+            TrackedFrame, "detection_tracked", self.callback_detection_traced, 10
+        )
 
         qos_profile = QoSProfile(
-            depth=1,
-            durability=DurabilityPolicy.TRANSIENT_LOCAL,
-            reliability=ReliabilityPolicy.RELIABLE
+            depth=1, durability=DurabilityPolicy.TRANSIENT_LOCAL, reliability=ReliabilityPolicy.RELIABLE
         )
 
         self._sub_param_rule = self.create_subscription(
-            String, 'consai_param/rule', self.callback_param_rule, qos_profile)
+            String, "consai_param/rule", self.callback_param_rule, qos_profile
+        )
 
     def update(self) -> None:
+        """
+        タイマーにより定期的に呼び出され、WorldModelの状態を更新する.
+
+        ロボットのアクティビティやボール位置を再計算する.
+        """
         with self.lock:
-            self.get_logger().debug(f'WorldModelProvider update, {process_info()}')
+            self.get_logger().debug(f"WorldModelProvider update, {process_info()}")
             self.world_model.robot_activity.update(self.world_model.robots)
             # ボールの位置情報を更新
             self.world_model.ball_position.update_position(
-                self.world_model.ball,
-                self.world_model.field,
-                self.world_model.field_points)
+                self.world_model.ball, self.world_model.field, self.world_model.field_points
+            )
 
     def callback_referee(self, msg: Referee) -> None:
+        """メッセージ Referee を受信して WorldModel に反映する."""
         with self.lock:
             self.world_model.referee.parse_msg(msg)
 
     def callback_detection_traced(self, msg: TrackedFrame) -> None:
+        """メッセージ TrackedFrame を受信してロボットとボールの状態を更新する."""
         with self.lock:
             self.world_model.robots.parse_frame(msg)
             self.world_model.ball.parse_frame(msg)
 
     def callback_param_rule(self, msg: String) -> None:
+        """トピック consai_param/rule からのパラメータを受け取り、フィールドの寸法を更新する."""
         with self.lock:
             param_dict = json.loads(msg.data)
-            self.world_model.field.length = param_dict['field']['length']
-            self.world_model.field.width = param_dict['field']['width']
-            self.world_model.field.goal_width = param_dict['field']['goal_width']
-            self.world_model.field.penalty_depth = param_dict['field']['penalty_depth']
-            self.world_model.field.penalty_width = param_dict['field']['penalty_width']
-            self.world_model.field_points = self.world_model.field_points.create_field_points(
-                self.world_model.field
-            )
+            self.world_model.field.length = param_dict["field"]["length"]
+            self.world_model.field.width = param_dict["field"]["width"]
+            self.world_model.field.goal_width = param_dict["field"]["goal_width"]
+            self.world_model.field.penalty_depth = param_dict["field"]["penalty_depth"]
+            self.world_model.field.penalty_width = param_dict["field"]["penalty_width"]
+
+            self.world_model.field.half_length = self.world_model.field.length / 2
+            self.world_model.field.half_width = self.world_model.field.width / 2
+            self.world_model.field.half_goal_width = self.world_model.field.goal_width / 2
+            self.world_model.field.half_penalty_depth = self.world_model.field.penalty_depth / 2
+            self.world_model.field.half_penalty_width = self.world_model.field.penalty_width / 2
+
+            self.world_model.field_points = self.world_model.field_points.create_field_points(self.world_model.field)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 120
-ignore = Q000, W503
+ignore = D403, Q000, W503

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 120
+ignore = Q000, W503


### PR DESCRIPTION
チケット：https://github.com/orgs/SSL-Roots/projects/7/views/1?pane=issue&itemId=106158744

- ament_flake8を満たすようにコードを整形
- 以下のメンバ変数として登録し，`self._field.length / 2`などを置き換えた

```python
    half_length = length / 2
    half_width = width / 2
    half_goal_width = goal_width / 2
    half_penalty_depth = penalty_depth / 2
    half_penalty_width = penalty_width / 2
```