### PR TITLE
やばいロボットランキングモデルを追加

### DIFF
--- a/consai_game/consai_game/world_model/threats_model.py
+++ b/consai_game/consai_game/world_model/threats_model.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# coding: UTF-8
+
+# Copyright 2025 Roots
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import List
+
+from consai_msgs.msg import State2D
+from consai_game.world_model.field_model import Field, FieldPoints
+from consai_game.world_model.robots_model import RobotsModel
+from consai_tools.geometry import geometry_tools as tools
+
+
+@dataclass
+class Threat:
+    score: int  # 0以上
+    robot_id: int  # 相手のロボットID
+
+
+class ThreatsModel:
+    def __init__(self, field: Field, field_points: FieldPoints):
+        self.threats: List[Threat] = []
+        self._field = field
+        self._field_points = field_points
+
+    def update(self, robots: RobotsModel):
+        """敵ロボットの驚異度を更新する
+
+        Args:
+            robots: ロボットのリスト
+        """
+        self.threats = []
+
+        # 敵ロボットのみを対象とする（is_visibleがtrueのものだけ）
+        for robot_id, robot in robots.their_robots.items():
+            if not robot.is_visible:
+                continue
+
+            # Aゴールへの距離を計算
+            goal = State2D(x=self._field_points.our_goal_top.x, y=0.0)
+            distance = tools.get_distance(goal, robot.pos)
+
+            # 距離が近いほどスコアが高くなるように計算
+            # フィールドの長さを基準にスコアを計算
+            max_distance = self._field.length
+            score = int((max_distance - distance) * 100 / max_distance)
+
+            threat = Threat(score=score, robot_id=robot_id)
+            self.threats.append(threat)
+
+        # スコアの高い順にソート
+        self.threats.sort(key=lambda x: x.score, reverse=True)

--- a/consai_game/consai_game/world_model/threats_model.py
+++ b/consai_game/consai_game/world_model/threats_model.py
@@ -16,11 +16,12 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import List
+from typing import List, Dict
 
 from consai_msgs.msg import State2D
 from consai_game.world_model.field_model import Field, FieldPoints
 from consai_game.world_model.robots_model import RobotsModel
+from consai_game.world_model.ball_model import BallModel
 from consai_tools.geometry import geometry_tools as tools
 
 
@@ -35,11 +36,33 @@ class ThreatsModel:
         self.threats: List[Threat] = []
         self._field = field
         self._field_points = field_points
+        self._prev_scores: Dict[int, float] = {}  # ロボットIDごとの前回のスコア
+        self._alpha = 0.05  # ローパスフィルターの係数（0-1、小さいほど変化が遅い）
 
-    def update(self, robots: RobotsModel):
+    def _apply_low_pass_filter(self, robot_id: int, new_score: float) -> float:
+        """ローパスフィルターを適用してスコアを平滑化する
+
+        Args:
+            robot_id: ロボットID
+            new_score: 新しいスコア
+
+        Returns:
+            平滑化されたスコア
+        """
+        if robot_id not in self._prev_scores:
+            self._prev_scores[robot_id] = new_score
+            return new_score
+
+        # 前回のスコアと新しいスコアを重み付けして結合
+        filtered_score = self._prev_scores[robot_id] * (1 - self._alpha) + new_score * self._alpha
+        self._prev_scores[robot_id] = filtered_score
+        return filtered_score
+
+    def update(self, ball: BallModel, robots: RobotsModel):
         """敵ロボットの驚異度を更新する
 
         Args:
+            ball: ボールの情報
             robots: ロボットのリスト
         """
         self.threats = []
@@ -49,16 +72,44 @@ class ThreatsModel:
             if not robot.is_visible:
                 continue
 
-            # Aゴールへの距離を計算
+            # A: ゴールへの距離を計算
             goal = State2D(x=self._field_points.our_goal_top.x, y=0.0)
-            distance = tools.get_distance(goal, robot.pos)
+            goal_distance = tools.get_distance(goal, robot.pos)
 
-            # 距離が近いほどスコアが高くなるように計算
-            # フィールドの長さを基準にスコアを計算
+            # B: シュートできるか（ゴールとの間に障害物があるか）
+            can_shoot = True
+            for other_robot in robots.our_robots.values():
+                if not other_robot.is_visible:
+                    continue
+                # ロボットとゴールを結ぶ直線上に他のロボットがいるかチェック
+                if tools.is_on_line(
+                    pose=other_robot.pos, line_pose1=robot.pos, line_pose2=goal, tolerance=0.1  # ロボットの半径を考慮
+                ):
+                    can_shoot = False
+                    break
+
+            # C: ボールとの距離を計算
+            ball_distance = tools.get_distance(robot.pos, ball.pos)
+
+            # 各要素のスコアを計算
+            # A: ゴールへの距離（近いほど高スコア）
             max_distance = self._field.length
-            score = int((max_distance - distance) * 100 / max_distance)
+            score_a = int((max_distance - goal_distance) * 100 / max_distance)
 
-            threat = Threat(score=score, robot_id=robot_id)
+            # B: シュートできるか（できる場合高スコア）
+            score_b = 100 if can_shoot else 0
+
+            # C: ボールとの距離（近いほど高スコア）
+            max_ball_distance = self._field.length
+            score_c = int((max_ball_distance - ball_distance) * 100 / max_ball_distance)
+
+            # 総合スコアを計算（A:40%, B:30%, C:30%）
+            total_score = int(score_a * 0.4 + score_b * 0.3 + score_c * 0.3)
+
+            # ローパスフィルターを適用
+            filtered_score = self._apply_low_pass_filter(robot_id, total_score)
+
+            threat = Threat(score=int(filtered_score), robot_id=robot_id)
             self.threats.append(threat)
 
         # スコアの高い順にソート

--- a/consai_game/consai_game/world_model/threats_model.py
+++ b/consai_game/consai_game/world_model/threats_model.py
@@ -15,6 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+敵ロボットの驚異度を計算し、驚異度の高い順にソートするモジュール.
+
+驚異度は敵ロボットのゴールへの距離, シュートできるか, ボールとの距離の3つの要素から計算される.
+"""
+
 from dataclasses import dataclass
 from typing import List, Dict
 
@@ -37,7 +43,7 @@ class ThreatsModel:
         self._field = field
         self._field_points = field_points
         self._prev_scores: Dict[int, float] = {}  # ロボットIDごとの前回のスコア
-        self._alpha = 0.05  # ローパスフィルターの係数（0-1、小さいほど変化が遅い）
+        self._alpha = 0.1  # ローパスフィルターの係数（0-1、小さいほど変化が遅い）
 
     def _apply_low_pass_filter(self, robot_id: int, new_score: float) -> float:
         """ローパスフィルターを適用してスコアを平滑化する

--- a/consai_game/consai_game/world_model/visualize_msg_publisher_node.py
+++ b/consai_game/consai_game/world_model/visualize_msg_publisher_node.py
@@ -38,6 +38,10 @@ class VisualizeMsgPublisherNode(Node):
             self.ball_activity_to_vis_msg(activity=world_model.ball_activity, ball=world_model.ball)
         )
 
+        self.pub_visualizer_objects.publish(
+            self.threats_to_vis_msg(threats=world_model.threats, robots=world_model.robots)
+        )
+
     def kick_target_to_vis_msg(self, kick_target: KickTargetModel, ball: BallModel) -> Objects:
         """kick_targetをObjectsメッセージに変換する."""
         vis_obj = Objects()
@@ -100,5 +104,25 @@ class VisualizeMsgPublisherNode(Node):
             state_circle.line_color.name = THEIR_COLOR
             state_circle.fill_color.name = THEIR_COLOR
             vis_obj.circles.append(state_circle)
+
+        return vis_obj
+
+    def threats_to_vis_msg(self, threats, robots) -> Objects:
+        """threatsをObjectsメッセージに変換する."""
+        vis_obj = Objects()
+        vis_obj.layer = "game"
+        vis_obj.sub_layer = "threats"
+        vis_obj.z_order = 4
+
+        # 各ロボットの上に驚異度を表示
+        for i, threat in enumerate(threats.threats):
+            robot = robots.their_robots[threat.robot_id]
+            text = ShapeText()
+            text.text = f"{i+1}: [{threat.score}]"
+            text.x = robot.pos.x - 0.2
+            text.y = robot.pos.y + 0.2  # ロボットの上に表示
+            text.size = 12
+            text.color.name = "red"
+            vis_obj.texts.append(text)
 
         return vis_obj

--- a/consai_game/consai_game/world_model/world_model.py
+++ b/consai_game/consai_game/world_model/world_model.py
@@ -25,6 +25,7 @@ from consai_game.world_model.robot_activity_model import RobotActivityModel
 from consai_game.world_model.robots_model import RobotsModel
 from consai_game.world_model.kick_target_model import KickTargetModel
 from consai_game.world_model.game_config_model import GameConfigModel
+from consai_game.world_model.threats_model import ThreatsModel
 
 
 @dataclass
@@ -39,3 +40,4 @@ class WorldModel:
     ball_activity: BallActivityModel = BallActivityModel()
     kick_target: KickTargetModel = KickTargetModel()
     game_config: GameConfigModel = GameConfigModel()
+    threats: ThreatsModel = ThreatsModel(field, field_points)

--- a/consai_game/consai_game/world_model/world_model_provider_node.py
+++ b/consai_game/consai_game/world_model/world_model_provider_node.py
@@ -100,6 +100,10 @@ class WorldModelProviderNode(Node):
                 self.world_model.ball,
                 self.world_model.robots,
             )
+            # 敵ロボットの驚異度を更新
+            self.world_model.threats.update(
+                self.world_model.robots,
+            )
 
     def callback_referee(self, msg: Referee) -> None:
         """メッセージ Referee を受信して WorldModel に反映する."""

--- a/consai_game/consai_game/world_model/world_model_provider_node.py
+++ b/consai_game/consai_game/world_model/world_model_provider_node.py
@@ -102,7 +102,8 @@ class WorldModelProviderNode(Node):
             )
             # 敵ロボットの驚異度を更新
             self.world_model.threats.update(
-                self.world_model.robots,
+                ball=self.world_model.ball,
+                robots=self.world_model.robots,
             )
 
     def callback_referee(self, msg: Referee) -> None:


### PR DESCRIPTION
https://github.com/orgs/SSL-Roots/projects/7/views/1?pane=issue&itemId=107270074

やばいロボットランキングを実装したよ
ゴールへの距離、シュートできそうか、ボールに近いかを
4:3:3の割合で評価しているよ
特に根拠はないから調整するべきだよ

ローパスフィルターも一応いれているよ
alphaをいじって調整するべきだよ
いまの値に根拠はないよ

GUIのgameのところに項目を追加したので敵の上に驚異度が出るよ
順位とスコアが表示されるよ
![image](https://github.com/user-attachments/assets/d4eba0b3-1592-46aa-a3fe-8ec67a12c94b)

終わりだよ