### PR TITLE
Refactor kick target to shoot target

### DIFF
--- a/consai_game/consai_game/world_model/visualize_msg_publisher_node.py
+++ b/consai_game/consai_game/world_model/visualize_msg_publisher_node.py
@@ -55,7 +55,7 @@ class VisualizeMsgPublisherNode(Node):
         vis_obj.z_order = 4
 
         # ボールとターゲットを結ぶ直線を引く
-        for i, target in enumerate(kick_target.kick_target_list):
+        for i, target in enumerate(kick_target.shoot_target_list):
             line = ShapeLine()
             line.p1.x = ball.pos.x
             line.p1.y = ball.pos.y
@@ -65,7 +65,7 @@ class VisualizeMsgPublisherNode(Node):
             line.size = 1
             line.color.name = "black"
             # ベストシュートターゲットの色を赤にする
-            if i == kick_target.best_target_index:
+            if i == 0:
                 line.color.name = "red"
 
             # シュート成功率が高いほど色を刻する


### PR DESCRIPTION
kick_target_modelのリファクタリング
チケット→https://github.com/orgs/SSL-Roots/projects/7?pane=issue&itemId=107441577

## 修正点
- kick_target_listはshoot_target_listに改名
- best_target_indexを廃止
- best_target_indexがなくなったことで描画するコードで存在しない変数参照しようとしていたため、修正
- shoot_targetのスコア計算の際にすべてのターゲットの計算結果を加算し続けていたので修正

## 今後改善が必要そうなところ（別のチケットで対応したい）
- スコア計算が正常になりましたけど、成功率を割り出す処理もう少し賢くしたい
- 計算上のロボット半径を実際のロボットの直径に設定してそれでもシュート決めるところの成功率引き上げとかしたほうがいいかもしれません