### PR TITLE
Add CompositeOffense tactic

### DIFF
--- a/consai_game/consai_game/play/factory/simple_plays.py
+++ b/consai_game/consai_game/play/factory/simple_plays.py
@@ -25,9 +25,11 @@
 from consai_game.core.play.play import Play, invert_conditions
 from consai_game.play.conditions.referee_conditions import RefereeConditions
 from consai_game.tactic.slow_safe_position import SlowSafePosition
+from consai_game.tactic.position import Position
 from consai_game.tactic.stop import Stop
 from consai_game.tactic.kick.shoot import Shoot
 from consai_game.tactic.composite.chase_or_position import ChaseOrPosition
+from consai_game.tactic.composite.composite_offense import CompositeOffense
 
 
 def halt() -> Play:
@@ -97,16 +99,16 @@ def force_start() -> Play:
         timeout_ms=0,
         roles=[
             [Stop()],
-            [Shoot()],
-            [Stop()],
-            [Stop()],
-            [Stop()],
-            [Stop()],
-            [Stop()],
-            [Stop()],
-            [Stop()],
-            [Stop()],
-            [Stop()],
+            [CompositeOffense(tactic_default=Position(-3.0, 2.0))],
+            [CompositeOffense(tactic_default=Position(-3.0, 0.0))],
+            [CompositeOffense(tactic_default=Position(-3.0, -2.0))],
+            [CompositeOffense(tactic_default=Position(0.0, 4.0))],
+            [CompositeOffense(tactic_default=Position(0.0, 2.0))],
+            [CompositeOffense(tactic_default=Position(0.0, -2.0))],
+            [CompositeOffense(tactic_default=Position(0.0, -4.0))],
+            [CompositeOffense(tactic_default=Position(3.0, 3.0))],
+            [CompositeOffense(tactic_default=Position(3.0, -3.0))],
+            [CompositeOffense(tactic_default=Position(4.0, 0.0))],
         ],
     )
 

--- a/consai_game/consai_game/tactic/composite/composite_offense.py
+++ b/consai_game/consai_game/tactic/composite/composite_offense.py
@@ -1,0 +1,66 @@
+# Copyright 2025 Roots
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+条件に応じてキックやパスを切り替えるTactic
+"""
+
+from consai_game.core.tactic.tactic_base import TacticBase, TacticState
+from consai_game.tactic.kick.kick import Kick
+from consai_game.world_model.world_model import WorldModel
+
+from consai_msgs.msg import MotionCommand
+
+
+class CompositeOffense(TacticBase):
+    def __init__(self, tactic_default: TacticBase):
+        super().__init__()
+        self.tactic_shoot = Kick(is_pass=False)
+        self.tactic_pass = Kick(is_pass=True)
+        self.tactic_default = tactic_default
+
+    def reset(self, robot_id: int) -> None:
+        """Reset the tactic state for the specified robot."""
+        self.robot_id = robot_id
+        self.state = TacticState.RUNNING
+
+        # 所有するTacticも初期化する
+        self.tactic_shoot.reset(robot_id)
+        self.tactic_pass.reset(robot_id)
+        self.tactic_default.reset(robot_id)
+
+    def run(self, world_model: WorldModel) -> MotionCommand:
+        if world_model.robot_activity.our_robots_by_ball_distance[0] == self.robot_id:
+            # ボールに近い場合はボールを操作する
+            return self.control_the_ball(world_model)
+
+        # ボールに近くない場合はデフォルトのtacticを実行する
+        return self.tactic_default.run(world_model)
+
+    def control_the_ball(self, world_model: WorldModel) -> MotionCommand:
+        """ボールを制御するためのTacticを実行する関数."""
+
+        if world_model.kick_target.best_shoot_target.success_rate > 50:
+            # シュートできる場合
+            self.tactic_shoot.target_pos = world_model.kick_target.best_shoot_target.pos
+            return self.tactic_shoot.run(world_model)
+
+        elif world_model.kick_target.best_pass_target.success_rate > 50:
+            # パスできる場合
+            self.tactic_pass.target_pos = world_model.kick_target.best_pass_target.robot_pos
+            return self.tactic_pass.run(world_model)
+
+        # TODO: コツコツドリブルを実行する
+        self.tactic_pass.target_pos = world_model.robots.our_visible_robots[self.robot_id].pos
+        return self.tactic_pass.run(world_model)

--- a/consai_game/consai_game/tactic/composite/composite_offense.py
+++ b/consai_game/consai_game/tactic/composite/composite_offense.py
@@ -41,6 +41,7 @@ class CompositeOffense(TacticBase):
         self.tactic_default.reset(robot_id)
 
     def run(self, world_model: WorldModel) -> MotionCommand:
+        """状況に応じて実行するtacticを切り替えてrunする."""
         if world_model.robot_activity.our_robots_by_ball_distance[0] == self.robot_id:
             # ボールに近い場合はボールを操作する
             return self.control_the_ball(world_model)

--- a/consai_game/consai_game/tactic/kick/kick.py
+++ b/consai_game/consai_game/tactic/kick/kick.py
@@ -77,7 +77,7 @@ class Kick(TacticBase):
     KICK_POWER_ON = 5.0
     CHASING_BALL_APPROACH_X = 0.5
 
-    def __init__(self, x: float, y: float, is_pass: bool):
+    def __init__(self, x=0.0, y=0.0, is_pass=False):
         super().__init__()
 
         self.target_pos = State2D(x=x, y=y)


### PR DESCRIPTION
パス・シュートを結合した`CompositeOffense`というTacticを追加します

自身がボールに一番近ければ、パスかシュートをする。
近くなければデフォルトのtactic （コンストラクタ引数で設定）　を実行する。
という処理が組み込まれてます。

## 何が嬉しいのか？

インプレイ中のPlayを書くとき、ひとまず`CompositeOffense`を全ロボットに設定すればよいです。
これにより、playファイルには陣形を書くだけになります。
（誰がパサーで、誰がシューターか、などを気にしなくてOK）

## できてないこと

- ボールの受け取り機能が未実装
- ボールのドリブル機能が未実装
  - パスもシュートもできないときは、その場でくるくる回るような動作になります。