### PR TITLE
Add our_ball_receive_score in robot_activity_model. CompositeOffense can receive ball.

### DIFF
--- a/consai_game/consai_game/tactic/composite/composite_offense.py
+++ b/consai_game/consai_game/tactic/composite/composite_offense.py
@@ -18,7 +18,9 @@
 
 from consai_game.core.tactic.tactic_base import TacticBase, TacticState
 from consai_game.tactic.kick.kick import Kick
+from consai_game.tactic.receive import Receive
 from consai_game.world_model.world_model import WorldModel
+
 
 from consai_msgs.msg import MotionCommand
 
@@ -28,6 +30,7 @@ class CompositeOffense(TacticBase):
         super().__init__()
         self.tactic_shoot = Kick(is_pass=False)
         self.tactic_pass = Kick(is_pass=True)
+        self.tactic_receive = Receive()
         self.tactic_default = tactic_default
 
     def reset(self, robot_id: int) -> None:
@@ -38,12 +41,24 @@ class CompositeOffense(TacticBase):
         # 所有するTacticも初期化する
         self.tactic_shoot.reset(robot_id)
         self.tactic_pass.reset(robot_id)
+        self.tactic_receive.reset(robot_id)
         self.tactic_default.reset(robot_id)
 
     def run(self, world_model: WorldModel) -> MotionCommand:
         """状況に応じて実行するtacticを切り替えてrunする."""
-        if world_model.robot_activity.our_robots_by_ball_distance[0] == self.robot_id:
-            # ボールに近い場合はボールを操作する
+
+        # ボールが動いている場合は、自分がレシーブできるかを判断する
+        best_receive_score = world_model.robot_activity.our_ball_receive_score[0]
+        if world_model.ball_activity.ball_is_moving:
+            if best_receive_score.robot_id == self.robot_id and best_receive_score.intercept_time != float("inf"):
+                # 自分がレシーブできる場合
+                return self.tactic_receive.run(world_model)
+            else:
+                # 自分がレシーブできない場合は、ボールを追いかけないようにデフォルトを実行する
+                return self.tactic_default.run(world_model)
+
+        elif world_model.robot_activity.our_robots_by_ball_distance[0] == self.robot_id:
+            # ボールに一番近い場合はボールを操作する
             return self.control_the_ball(world_model)
 
         # ボールに近くない場合はデフォルトのtacticを実行する
@@ -57,7 +72,7 @@ class CompositeOffense(TacticBase):
             self.tactic_shoot.target_pos = world_model.kick_target.best_shoot_target.pos
             return self.tactic_shoot.run(world_model)
 
-        elif world_model.kick_target.best_pass_target.success_rate > 50:
+        elif world_model.kick_target.best_pass_target.success_rate > 30:
             # パスできる場合
             self.tactic_pass.target_pos = world_model.kick_target.best_pass_target.robot_pos
             return self.tactic_pass.run(world_model)

--- a/consai_game/consai_game/world_model/robot_activity_model.py
+++ b/consai_game/consai_game/world_model/robot_activity_model.py
@@ -150,7 +150,6 @@ class RobotActivityModel:
         # ボールが到達するまでの時間で、ロボットがどれだけ移動できるかを計算する
         # TODO: ロボットの現在速度、加速度を考慮すべき
         available_distance = intercept_time * game_config.robot_max_linear_vel
-        print(f"robot_id: {robot.robot_id}, intercept_time: {intercept_time}, available_distance: {available_distance}")
 
         # ボール軌道からロボットまでの距離
         robot_arrival_distance = tr_robot_pos.y

--- a/consai_game/consai_game/world_model/robot_activity_model.py
+++ b/consai_game/consai_game/world_model/robot_activity_model.py
@@ -152,7 +152,7 @@ class RobotActivityModel:
         available_distance = intercept_time * game_config.robot_max_linear_vel
 
         # ボール軌道からロボットまでの距離
-        robot_arrival_distance = tr_robot_pos.y
+        robot_arrival_distance = abs(tr_robot_pos.y)
 
         # ボールが到着するまでにロボットが移動できれば、intercept_timeを返す
         if available_distance >= robot_arrival_distance:

--- a/consai_game/consai_game/world_model/world_model_provider_node.py
+++ b/consai_game/consai_game/world_model/world_model_provider_node.py
@@ -96,7 +96,6 @@ class WorldModelProviderNode(Node):
             self.world_model.ball_activity.update(
                 ball=self.world_model.ball,
                 robots=self.world_model.robots,
-                robot_activity=self.world_model.robot_activity,
             )
             # 最適なシュートターゲットを更新
             self.world_model.kick_target.update(

--- a/consai_game/consai_game/world_model/world_model_provider_node.py
+++ b/consai_game/consai_game/world_model/world_model_provider_node.py
@@ -88,11 +88,11 @@ class WorldModelProviderNode(Node):
         """
         with self.lock:
             self.get_logger().debug(f"WorldModelProvider update, {process_info()}")
-            self.world_model.robot_activity.update(self.world_model.robots, ball=self.world_model.ball)
             # ボールの位置情報を更新
             self.world_model.ball_position.update_position(
                 self.world_model.ball, self.world_model.field, self.world_model.field_points
             )
+            # ボールの活動状態を更新
             self.world_model.ball_activity.update(
                 ball=self.world_model.ball,
                 robots=self.world_model.robots,
@@ -106,6 +106,13 @@ class WorldModelProviderNode(Node):
             self.world_model.threats.update(
                 ball=self.world_model.ball,
                 robots=self.world_model.robots,
+            )
+            # ロボットの活動状態を更新
+            self.world_model.robot_activity.update(
+                robots=self.world_model.robots,
+                ball=self.world_model.ball,
+                ball_activity=self.world_model.ball_activity,
+                game_config=self.world_model.game_config,
             )
 
     def callback_referee(self, msg: Referee) -> None:

--- a/consai_tools/consai_tools/geometry/geometry_tools.py
+++ b/consai_tools/consai_tools/geometry/geometry_tools.py
@@ -77,6 +77,11 @@ def get_angle(from_pose, to_pose):
     return math.atan2(diff_pose.y, diff_pose.x)
 
 
+def get_vel_angle(vel: State2D) -> float:
+    # ワールド座標系での速度ベクトルの角度を得る
+    return math.atan2(vel.y, vel.x)
+
+
 def angle_normalize(angle):
     # 角度をpi  ~ -piの範囲に変換する関数
     while angle > math.pi:


### PR DESCRIPTION
ボールを受け取れるランキングをRobotActivityModelに追加します。
また、CompositeOffenseでボールを受け取れるようにします。

こんな感じに使用できます。

```python
# ボールが動いている場合は、自分がレシーブできるかを判断する
        best_receive_score = world_model.robot_activity.our_ball_receive_score[0]
        if world_model.ball_activity.ball_is_moving:
            if best_receive_score.robot_id == self.robot_id and best_receive_score.intercept_time != float("inf"):
                # 自分がレシーブできる場合
```

scoreのintercept_timeにはボールを受け取るまでの時間が入ります。受け取れない場合はinfです。

## その他の変更

- ball_activity_modelからrobot_activityの依存関係を取り除きました
  - robot_activityがball_activityの情報を使うためです。（対策しないと循環参照する）

## できてないこと

- ボールを後ろから追いかけて受け取ることには対応してません。
- ボールが減速して止まることは考慮してません
- ロボットの初速度と加速度は考慮してません
