### PR TITLE
Implement reset and exit methods to TacticBase

### DIFF
--- a/consai_game/consai_game/core/tactic/agent.py
+++ b/consai_game/consai_game/core/tactic/agent.py
@@ -83,5 +83,8 @@ class Agent:
 
     def reset_tactic(self) -> None:
         """戦術をリセットし, 次の戦術を設定する関数."""
+        if self.present_tactic is not None:
+            self.present_tactic.exit()
+
         self.present_tactic = self.role.tactics[self.present_tactic_index]
         self.present_tactic.reset(self.role.robot_id)

--- a/consai_game/consai_game/core/tactic/tactic_base.py
+++ b/consai_game/consai_game/core/tactic/tactic_base.py
@@ -43,14 +43,14 @@ class TacticBase(ABC):
         self._state = TacticState.BEFORE_INIT
 
     @abstractmethod
-    def reset(self, robot_id: int) -> None:
-        """戦術のリセット処理を行う関数."""
-        raise NotImplementedError()
-
-    @abstractmethod
     def run(self, world_model: WorldModel) -> MotionCommand:
         """戦術の実行を行い、MotionCommandを返す関数."""
         raise NotImplementedError()
+
+    def reset(self, robot_id: int) -> None:
+        """ロボットIDを設定し、Tacticの状態をRUNNINGにリセットする関数."""
+        self.robot_id = robot_id
+        self.state = TacticState.RUNNING
 
     @property
     def robot_id(self) -> int:

--- a/consai_game/consai_game/core/tactic/tactic_base.py
+++ b/consai_game/consai_game/core/tactic/tactic_base.py
@@ -52,6 +52,10 @@ class TacticBase(ABC):
         self.robot_id = robot_id
         self.state = TacticState.RUNNING
 
+    def exit(self) -> None:
+        """戦術の状態をFINISHEDにリセットする関数."""
+        self.state = TacticState.FINISHED
+
     @property
     def robot_id(self) -> int:
         """ロボットのIDを取得する関数."""

--- a/consai_game/consai_game/tactic/composite/composite_offense.py
+++ b/consai_game/consai_game/tactic/composite/composite_offense.py
@@ -16,7 +16,7 @@
 条件に応じてキックやパスを切り替えるTactic
 """
 
-from consai_game.core.tactic.tactic_base import TacticBase, TacticState
+from consai_game.core.tactic.tactic_base import TacticBase
 from consai_game.tactic.kick.kick import Kick
 from consai_game.tactic.receive import Receive
 from consai_game.world_model.world_model import WorldModel
@@ -36,8 +36,7 @@ class CompositeOffense(TacticBase):
 
     def reset(self, robot_id: int) -> None:
         """Reset the tactic state for the specified robot."""
-        self.robot_id = robot_id
-        self.state = TacticState.RUNNING
+        super().reset(robot_id)
 
         # 所有するTacticも初期化する
         self.tactic_shoot.reset(robot_id)

--- a/consai_game/consai_game/tactic/position.py
+++ b/consai_game/consai_game/tactic/position.py
@@ -17,7 +17,7 @@
 from consai_msgs.msg import MotionCommand
 
 from consai_game.world_model.world_model import WorldModel
-from consai_game.core.tactic.tactic_base import TacticBase, TacticState
+from consai_game.core.tactic.tactic_base import TacticBase
 
 
 class Position(TacticBase):
@@ -29,11 +29,6 @@ class Position(TacticBase):
         self.x = x
         self.y = y
         self.theta = theta
-
-    def reset(self, robot_id: int) -> None:
-        """ロボットIDを設定し、Tacticの状態をRUNNINGにリセットする関数."""
-        self.robot_id = robot_id
-        self.state = TacticState.RUNNING
 
     def run(self, world_model: WorldModel) -> MotionCommand:
         """指定した位置に移動するためのMotionCommandを生成する関数."""


### PR DESCRIPTION

TacticBaseにreset関数とexit関数を追加します

## resetについて

reset関数を抽象関数から通常の関数に変更し、
これまで各Tacticに実装していたコードを移植しています。

もし、各Tacticでオリジナルのreset関数を実装したい場合は`super().reset(robot_id)`を呼んでください

例として、`CompositeOffense`と`Position`を書き換えてます。

## exit関数について

Tacticにデストラクタ的な関数がほしい。という要望をもとに実装しました。
Tacticが切り替わるときに実行されます。