### PR TITLE
Add allow_move_in_defense_area wrapper. Implement goalie to all play

### DIFF
--- a/consai_game/consai_game/play/factory/running_plays.py
+++ b/consai_game/consai_game/play/factory/running_plays.py
@@ -24,6 +24,8 @@ from consai_game.play.conditions.referee_conditions import RefereeConditions
 from consai_game.tactic.position import Position
 from consai_game.tactic.stop import Stop
 from consai_game.tactic.kick.shoot import Shoot
+from consai_game.tactic.wrapper.allow_move_in_defense_area import AllowMoveInDefenseArea
+from consai_game.tactic.defend_goal import DefendGoal
 
 
 def outside_defense_area() -> Play:
@@ -40,7 +42,7 @@ def outside_defense_area() -> Play:
         aborted=invert_conditions(applicable),
         timeout_ms=0,
         roles=[
-            [Position(-6.0, 0.0)],
+            [AllowMoveInDefenseArea(DefendGoal())],
             [Shoot()],
             [Position(-3.0, 2.0)],
             [Position(-3.0, 1.0)],
@@ -68,7 +70,7 @@ def in_our_defense_area() -> Play:
         aborted=invert_conditions(applicable),
         timeout_ms=0,
         roles=[
-            [Shoot()],
+            [AllowMoveInDefenseArea(DefendGoal())],
             [Stop()],
             [Stop()],
             [Stop()],
@@ -96,7 +98,7 @@ def in_their_defense_area() -> Play:
         aborted=invert_conditions(applicable),
         timeout_ms=0,
         roles=[
-            [Stop()],
+            [AllowMoveInDefenseArea(DefendGoal())],
             [Stop()],
             [Stop()],
             [Stop()],

--- a/consai_game/consai_game/play/factory/simple_plays.py
+++ b/consai_game/consai_game/play/factory/simple_plays.py
@@ -24,13 +24,14 @@
 
 from consai_game.core.play.play import Play, invert_conditions
 from consai_game.play.conditions.referee_conditions import RefereeConditions
-from consai_game.tactic.slow_safe_position import SlowSafePosition
 from consai_game.tactic.position import Position
 from consai_game.tactic.stop import Stop
 from consai_game.tactic.kick.shoot import Shoot
 from consai_game.tactic.composite.chase_or_position import ChaseOrPosition
 from consai_game.tactic.composite.composite_offense import CompositeOffense
 from consai_game.tactic.wrapper.wrapper_look_ball import WrapperLookBall
+from consai_game.tactic.wrapper.allow_move_in_defense_area import AllowMoveInDefenseArea
+from consai_game.tactic.defend_goal import DefendGoal
 
 
 def halt() -> Play:
@@ -72,7 +73,7 @@ def stop() -> Play:
         aborted=invert_conditions(applicable),
         timeout_ms=0,
         roles=[
-            [SlowSafePosition(-6.0, 0.0)],
+            [AllowMoveInDefenseArea(DefendGoal())],
             [ChaseOrPosition(-3.0, 3.0)],
             [ChaseOrPosition(-3.0, 2.0)],
             [ChaseOrPosition(-3.0, 1.0)],
@@ -99,7 +100,7 @@ def force_start() -> Play:
         aborted=invert_conditions(applicable),
         timeout_ms=0,
         roles=[
-            [Stop()],
+            [AllowMoveInDefenseArea(DefendGoal())],
             [CompositeOffense(tactic_default=WrapperLookBall(Position(-3.0, 2.0)))],
             [CompositeOffense(tactic_default=WrapperLookBall(Position(-3.0, 0.0)))],
             [CompositeOffense(tactic_default=WrapperLookBall(Position(-3.0, -2.0)))],
@@ -127,7 +128,7 @@ def our_free_kick() -> Play:
         aborted=invert_conditions(applicable),
         timeout_ms=0,
         roles=[
-            [Stop()],
+            [AllowMoveInDefenseArea(DefendGoal())],
             [Shoot()],
             [Stop()],
             [Stop()],
@@ -155,7 +156,7 @@ def their_free_kick() -> Play:
         aborted=invert_conditions(applicable),
         timeout_ms=0,
         roles=[
-            [Stop()],
+            [AllowMoveInDefenseArea(DefendGoal())],
             [Stop()],
             [Stop()],
             [Stop()],
@@ -182,7 +183,7 @@ def our_kick_off() -> Play:
         aborted=invert_conditions(applicable),
         timeout_ms=0,
         roles=[
-            [Stop()],
+            [AllowMoveInDefenseArea(DefendGoal())],
             [Stop()],
             [Stop()],
             [Stop()],
@@ -209,7 +210,7 @@ def their_kick_off() -> Play:
         aborted=invert_conditions(applicable),
         timeout_ms=0,
         roles=[
-            [Stop()],
+            [AllowMoveInDefenseArea(DefendGoal())],
             [Stop()],
             [Stop()],
             [Stop()],
@@ -237,7 +238,7 @@ def our_kick_off_start() -> Play:
         aborted=invert_conditions(applicable),
         timeout_ms=0,
         roles=[
-            [Stop()],
+            [AllowMoveInDefenseArea(DefendGoal())],
             [Shoot()],
             [Stop()],
             [Stop()],
@@ -265,7 +266,7 @@ def their_kick_off_start() -> Play:
         aborted=invert_conditions(applicable),
         timeout_ms=0,
         roles=[
-            [Stop()],
+            [AllowMoveInDefenseArea(DefendGoal())],
             [Stop()],
             [Stop()],
             [Stop()],
@@ -292,7 +293,7 @@ def our_penalty_kick() -> Play:
         aborted=invert_conditions(applicable),
         timeout_ms=0,
         roles=[
-            [Stop()],
+            [AllowMoveInDefenseArea(DefendGoal())],
             [Stop()],
             [Stop()],
             [Stop()],
@@ -319,7 +320,7 @@ def their_penalty_kick() -> Play:
         aborted=invert_conditions(applicable),
         timeout_ms=0,
         roles=[
-            [Stop()],
+            [AllowMoveInDefenseArea(Position(-6.0, 0.0))],
             [Stop()],
             [Stop()],
             [Stop()],
@@ -346,7 +347,7 @@ def our_penalty_kick_start() -> Play:
         aborted=invert_conditions(applicable),
         timeout_ms=0,
         roles=[
-            [Stop()],
+            [AllowMoveInDefenseArea(DefendGoal())],
             [Shoot()],
             [Stop()],
             [Stop()],
@@ -373,7 +374,7 @@ def their_penalty_kick_start() -> Play:
         aborted=invert_conditions(applicable),
         timeout_ms=0,
         roles=[
-            [Stop()],
+            [AllowMoveInDefenseArea(DefendGoal())],
             [Stop()],
             [Stop()],
             [Stop()],

--- a/consai_game/consai_game/tactic/defend_goal.py
+++ b/consai_game/consai_game/tactic/defend_goal.py
@@ -39,20 +39,10 @@ class DefendGoal(TacticBase):
         # ボールが動いているか判定する閾値
         self.ball_move_threshold = 0.1
 
-    def reset(self, robot_id: int) -> None:
-        """Reset the tactic state for the specified robot."""
-        self.robot_id = robot_id
-        self.state = TacticState.RUNNING
-
     def run(self, world_model: WorldModel) -> MotionCommand:
         """Run the tactic and return a MotionCommand based on the ball's position and movement."""
         command = MotionCommand()
         command.robot_id = self.robot_id
-
-        # ボールを回避をしない
-        command.navi_options.avoid_ball = False
-        # ディフェンスエリアを回避をしない
-        command.navi_options.avoid_defense_area = False
 
         # ボールが自チームエリアにあるか判定結果を取得
         is_in_our_side = world_model.ball_position.is_in_our_side()

--- a/consai_game/consai_game/tactic/wrapper/allow_move_in_defense_area.py
+++ b/consai_game/consai_game/tactic/wrapper/allow_move_in_defense_area.py
@@ -16,17 +16,16 @@ from consai_msgs.msg import MotionCommand
 
 from consai_game.world_model.world_model import WorldModel
 from consai_game.core.tactic.tactic_base import TacticBase
-from consai_tools.geometry import geometry_tools as tool
 
 
-class WrapperLookBall(TacticBase):
-    """ボールを見るようにthetaを上書きするWrapperTactic.
+class AllowMoveInDefenseArea(TacticBase):
+    """ディフェンスエリア内での移動を許可するWrapperTactic."
 
-    WrapperLookBall(tactic=Position()) のように使用する
+    AllowMoveInDefenseArea(tactic=Position()) のように使用する
     """
 
     def __init__(self, tactic=TacticBase):
-        """内部tacticを初期化する関数."""
+        """inner_tacticを初期化する関数."""
         super().__init__()
         self.inner_tactic = tactic
 
@@ -36,11 +35,13 @@ class WrapperLookBall(TacticBase):
         self.inner_tactic.reset(robot_id)
 
     def run(self, world_model: WorldModel) -> MotionCommand:
-        """ボールを見るようにdesired_poseを上書きする.`"""
+        """ディフェンスエリア内での移動と、ボールとの接触を許可する."""
         command = self.inner_tactic.run(world_model)
 
-        ball_pos = world_model.ball.pos
-        command.desired_pose.theta = tool.get_angle(command.desired_pose, ball_pos)
+        # ボールを回避をしない
+        command.navi_options.avoid_ball = False
+        # ディフェンスエリアを回避をしない
+        command.navi_options.avoid_defense_area = False
 
         # stateを上書きする
         self.state = self.inner_tactic.state

--- a/consai_game/consai_game/tactic/wrapper/allow_move_in_defense_area.py
+++ b/consai_game/consai_game/tactic/wrapper/allow_move_in_defense_area.py
@@ -30,7 +30,7 @@ class AllowMoveInDefenseArea(TacticBase):
         self.inner_tactic = tactic
 
     def reset(self, robot_id: int) -> None:
-        """iner_tacticをリセットする関数."""
+        """inner_tacticをリセットする関数."""
         super().reset(robot_id)
         self.inner_tactic.reset(robot_id)
 

--- a/consai_game/consai_game/tactic/wrapper/wrapper_look_ball.py
+++ b/consai_game/consai_game/tactic/wrapper/wrapper_look_ball.py
@@ -31,7 +31,7 @@ class WrapperLookBall(TacticBase):
         self.inner_tactic = tactic
 
     def reset(self, robot_id: int) -> None:
-        """iner_tacticをリセットする関数."""
+        """inner_tacticをリセットする関数."""
         super().reset(robot_id)
         self.inner_tactic.reset(robot_id)
 


### PR DESCRIPTION
AllowMoveInDefenseAreaというWrapperを追加します。

次のように使用できます

```python
AllowMoveInDefenseArea(DefendGoal())
```

また、GoalieをすべてのPlayに追加しました。

## その他の変更

- もともとDefendGoalで設定していたNaviOptionsを取り除きました。