### PR TITLE
Add consai_referee_parser. Support avoid_placement_area flag of navi_options.

### DIFF
--- a/consai_game/consai_game/tactic/slow_safe_position.py
+++ b/consai_game/consai_game/tactic/slow_safe_position.py
@@ -60,6 +60,5 @@ class SlowSafePosition(TacticBase):
         command.navi_options.avoid_their_robots = True
         command.navi_options.avoid_pushing = True
         command.navi_options.avoid_defense_area = True
-        command.navi_options.avoid_placement_area = True
 
         return command

--- a/consai_game/launch/start.launch
+++ b/consai_game/launch/start.launch
@@ -45,4 +45,11 @@
               --assign $(var assign)
               --goalie $(var goalie)
               " />
+
+  <node pkg="consai_referee_parser"
+        exec="main.py"
+        output="screen"
+        args="--yellow $(var yellow)
+              --invert $(var invert)
+              " />
 </launch>

--- a/consai_msgs/msg/NaviOptions.msg
+++ b/consai_msgs/msg/NaviOptions.msg
@@ -7,4 +7,4 @@ bool avoid_ball true  # ボールを避ける
 float64 ball_avoid_radius 0.001  # ボールを避ける半径 [m]
 
 bool avoid_defense_area true  # ディフェンスエリアを避ける
-bool avoid_placement_area true  # プレイスメントエリアを避ける
+bool avoid_placement_area false  # プレイスメントエリアを避ける

--- a/consai_referee_parser/CMakeLists.txt
+++ b/consai_referee_parser/CMakeLists.txt
@@ -1,0 +1,29 @@
+cmake_minimum_required(VERSION 3.8)
+project(consai_referee_parser)
+
+find_package(ament_cmake REQUIRED)
+
+ament_python_install_package(${PROJECT_NAME})
+file(GLOB_RECURSE PYTHON_SCRIPTS
+  RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/*.py
+)
+
+message("Found Python scripts:")
+foreach(SCRIPT ${PYTHON_SCRIPTS})
+  message(" - ${SCRIPT}")
+endforeach()
+
+install(
+  PROGRAMS ${PYTHON_SCRIPTS}
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_flake8 REQUIRED)
+  ament_flake8(
+    CONFIG_FILE ${CMAKE_CURRENT_SOURCE_DIR}/../setup.cfg
+  ) 
+endif()
+
+ament_package()

--- a/consai_referee_parser/consai_referee_parser/main.py
+++ b/consai_referee_parser/consai_referee_parser/main.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# coding: UTF-8
+
+# Copyright 2025 Roots
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+
+import rclpy
+from consai_referee_parser.referee_parser_node import RefereeParserNode
+
+
+if __name__ == "__main__":
+    arg_parser = argparse.ArgumentParser()
+
+    arg_parser.add_argument("--yellow", type=lambda x: x.lower() == "true", default=False)
+    arg_parser.add_argument("--invert", type=lambda x: x.lower() == "true", default=False)
+
+    args, other_args = arg_parser.parse_known_args()
+    rclpy.init(args=other_args)
+
+    parser_node = RefereeParserNode(team_is_yellow=args.yellow, invert=args.invert)
+
+    rclpy.spin(parser_node)
+
+    rclpy.shutdown()

--- a/consai_referee_parser/consai_referee_parser/referee_parser_node.py
+++ b/consai_referee_parser/consai_referee_parser/referee_parser_node.py
@@ -1,0 +1,44 @@
+# Copyright 2025 Roots
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+referee_parser_node モジュール.
+
+このモジュールは ROS2 ノードとして動作する.
+Referee メッセージを受け取り, consai_robot_controllerが使用できる形式でpublishする.
+"""
+
+import threading
+from rclpy.node import Node
+from robocup_ssl_msgs.msg import Referee
+
+
+class RefereeParserNode(Node):
+    """ """
+
+    def __init__(self, team_is_yellow: bool = False, invert: bool = False):
+        """
+        初期化.
+        """
+        super().__init__("referee_parser_node")
+        self.lock = threading.Lock()
+
+        self.team_is_yellow = team_is_yellow
+        self.invert = invert
+
+        self.sub_referee = self.create_subscription(Referee, "referee", self.callback_referee, 10)
+
+    def callback_referee(self, msg: Referee):
+        self.get_logger().info("referee_parser_node: referee msg received")

--- a/consai_referee_parser/package.xml
+++ b/consai_referee_parser/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>consai_referee_parser</name>
+  <version>0.1.0</version>
+  <description>This package provides a node that parse RoboCup SSL Referee message.</description>
+  <maintainer email="macakasit@gmail.com">shotaak</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/field_info_parser.hpp
@@ -59,6 +59,7 @@ public:
   void set_consai_param_rule(const nlohmann::json & param);
   void set_detection_tracked(const TrackedFrame::SharedPtr detection_tracked);
   void set_named_targets(const NamedTargets::SharedPtr msg);
+  void set_designated_position(const State::SharedPtr msg);
   bool is_parsable(const RobotControlMsg::SharedPtr goal) const;
   bool parse_goal(
     const RobotControlMsg::SharedPtr goal,
@@ -79,6 +80,7 @@ private:
 
   rclcpp::Subscription<TrackedFrame>::SharedPtr sub_detection_tracked_;
   rclcpp::Subscription<NamedTargets>::SharedPtr sub_named_targets_;
+  rclcpp::Subscription<State>::SharedPtr sub_designated_position_;
 
   bool team_is_yellow_ = false;
   bool invert_ = false;
@@ -91,6 +93,8 @@ private:
   std::shared_ptr<parser::ConstraintParser> constraint_parser_;
   std::shared_ptr<tactic::ControlBall> tactic_control_ball_;
   std::shared_ptr<tactic::ObstacleAvoidance> tactic_obstacle_avoidance_;
+
+  State designated_position_;
 };
 
 }  // namespace consai_robot_controller

--- a/consai_robot_controller/include/consai_robot_controller/tactic/tactic_obstacle_avoidance.hpp
+++ b/consai_robot_controller/include/consai_robot_controller/tactic/tactic_obstacle_avoidance.hpp
@@ -55,6 +55,11 @@ public:
   bool avoid_placement_area(
     const TrackedRobot & my_robot, const State & goal_pose, const TrackedBall & ball,
     const State & designated_position, State & avoidance_pose) const;
+  State avoid_placement_area(
+    const TrackedRobot & my_robot,
+    const State & goal_pose,
+    const std::optional<TrackedBall> & ball,
+    const State & designated_position) const;
   bool avoid_pushing_robots(
     const TrackedRobot & my_robot, const State & goal_pose,
     State & avoidance_pose) const;

--- a/consai_robot_controller/src/field_info_parser.cpp
+++ b/consai_robot_controller/src/field_info_parser.cpp
@@ -45,6 +45,10 @@ void FieldInfoParser::set_subscriptions(rclcpp::Node * node)
 
   sub_named_targets_ = node->create_subscription<NamedTargets>(
     "named_targets", qos, std::bind(&FieldInfoParser::set_named_targets, this, _1));
+
+  sub_designated_position_ = node->create_subscription<State>(
+    "parsed_referee/designated_position", qos,
+    std::bind(&FieldInfoParser::set_designated_position, this, _1));
 }
 
 void FieldInfoParser::set_consai_param_rule(const nlohmann::json & param)
@@ -60,6 +64,11 @@ void FieldInfoParser::set_detection_tracked(const TrackedFrame::SharedPtr detect
 void FieldInfoParser::set_named_targets(const NamedTargets::SharedPtr msg)
 {
   constraint_parser_->set_named_targets(msg);
+}
+
+void FieldInfoParser::set_designated_position(const State::SharedPtr msg)
+{
+  designated_position_ = *msg;
 }
 
 bool FieldInfoParser::is_parsable(const RobotControlMsg::SharedPtr goal) const
@@ -210,6 +219,11 @@ State FieldInfoParser::modify_goal_pose_to_avoid_obstacles(
 
   if (navi_options.avoid_defense_area) {
     new_pose = tactic_obstacle_avoidance_->avoid_defense_area(my_robot, new_pose);
+  }
+
+  if (navi_options.avoid_placement_area) {
+    new_pose = tactic_obstacle_avoidance_->avoid_placement_area(
+      my_robot, new_pose, ball, designated_position_);
   }
 
   return new_pose;

--- a/consai_robot_controller/src/tactic/tactic_obstacle_avoidance.cpp
+++ b/consai_robot_controller/src/tactic/tactic_obstacle_avoidance.cpp
@@ -233,6 +233,24 @@ bool ObstacleAvoidance::avoid_placement_area(
   return true;
 }
 
+State ObstacleAvoidance::avoid_placement_area(
+  const TrackedRobot & my_robot,
+  const State & goal_pose,
+  const std::optional<TrackedBall> & ball,
+  const State & designated_position) const
+{
+  State new_pose = goal_pose;
+
+  if (!ball) {
+    return new_pose;
+  }
+
+  avoid_placement_area(
+    my_robot, new_pose, *ball, designated_position, new_pose);
+
+  return new_pose;
+}
+
 bool ObstacleAvoidance::avoid_pushing_robots(
   const TrackedRobot & my_robot, const State & goal_pose,
   State & avoidance_pose) const


### PR DESCRIPTION
レフェリー信号をパースするconsai_referee_parser packagesを追加します。

プレースメント位置（designated_position）をconsai_robot_controllerへ送信するために使用します。

また、将来的にはReferee情報の描画トピックもpublishする予定です。

要するに、consai_examplesにあるparserのコードをここへ移植します。