### PR TITLE
defend_goal.pyにゴール回避を追加

### DIFF
--- a/consai_game/consai_game/tactic/defend_goal.py
+++ b/consai_game/consai_game/tactic/defend_goal.py
@@ -30,12 +30,13 @@ from consai_tools.geometry import geometry_tools as tool
 class DefendGoal(TacticBase):
     """自ゴールを守るTactic."""
 
+    # ロボットの半径[m]
+    ROBOT_RADIUS = 0.1
+
     def __init__(self):
         """Initialize the DefendGoal tactic."""
         super().__init__()
 
-        # ディフェンス位置(x座標)を調整する変数
-        self.margin_defend_x = 0.1
         # ボールが動いているか判定する閾値
         self.ball_move_threshold = 0.1
 
@@ -43,6 +44,9 @@ class DefendGoal(TacticBase):
         """Run the tactic and return a MotionCommand based on the ball's position and movement."""
         command = MotionCommand()
         command.robot_id = self.robot_id
+
+        # ロボットの位置を取得
+        robot_pos = world_model.robots.our_robots.get(self.robot_id).pos
 
         # ボールが自チームエリアにあるか判定結果を取得
         is_in_our_side = world_model.ball_position.is_in_our_side()
@@ -63,13 +67,13 @@ class DefendGoal(TacticBase):
             slope, intercept, flag = tool.get_line_parameter(ball_pos, next_ball_pos)
 
             # ゴール前のボール進行方向上の位置を計算
-            x = -world_model.field.half_length + self.margin_defend_x
+            x = -world_model.field.half_length + self.ROBOT_RADIUS
             y = slope * x + intercept
         elif is_in_our_defense_area:
             # ボールが自ディフェンスエリアにある場合
 
             # y座標をボールと同じ位置にする
-            x = -world_model.field.half_length + self.margin_defend_x
+            x = -world_model.field.half_length + self.ROBOT_RADIUS
             y = ball_pos.y
 
             # Stateの終了
@@ -78,7 +82,7 @@ class DefendGoal(TacticBase):
             # ボールがゴールへ向かって来ない場合
 
             # y座標をボールと同じ位置にする
-            x = -world_model.field.half_length + self.margin_defend_x
+            x = -world_model.field.half_length + self.ROBOT_RADIUS
             y = ball_pos.y
 
         if world_model.field.half_goal_width < abs(y):
@@ -86,6 +90,14 @@ class DefendGoal(TacticBase):
 
             # ゴール端になるようclamp
             y = max(min(y, world_model.field.half_goal_width), -world_model.field.half_goal_width)
+
+        # ロボットがゴールラインより後ろにいる場合に回避するための位置を生成
+        if robot_pos.x < -world_model.field.half_length:
+            x = -world_model.field.half_length + self.ROBOT_RADIUS
+            if robot_pos.y < -world_model.field.half_goal_width:
+                y = -(world_model.field.half_goal_width + self.ROBOT_RADIUS)
+            else:
+                y = world_model.field.half_goal_width + self.ROBOT_RADIUS
 
         command.desired_pose.x = x
         command.desired_pose.y = y


### PR DESCRIPTION
チケット：https://github.com/orgs/SSL-Roots/projects/7/views/1?pane=issue&itemId=107270418

- ゴール回避を追加した
- sim上でゴール側のフィールド外にゴーリーを置くと回避する様子が見れる
    - 遠くに置くと若干ゴールにぶつかるが，そのための処理を今書くのは手間なのでやめた
    - 今は突貫工事であり，いずれはcontrollerに入れるべきなので手間をかけるべきではない