### PR TITLE
CompositeDefense追加

### DIFF
--- a/consai_game/consai_game/play/factory/running_plays.py
+++ b/consai_game/consai_game/play/factory/running_plays.py
@@ -26,6 +26,9 @@ from consai_game.tactic.wrapper.allow_move_in_defense_area import AllowMoveInDef
 from consai_game.tactic.defend_goal import DefendGoal
 from consai_game.tactic.composite.composite_offense import CompositeOffense
 from consai_game.tactic.wrapper.wrapper_look_ball import WrapperLookBall
+from consai_game.tactic.composite.composite_defense import CompositeDefense
+from consai_game.tactic.center_back import CenterBack
+from consai_game.tactic.composite.composite_man_mark import CompositeManMark
 
 
 def outside_defense_area() -> Play:
@@ -42,17 +45,17 @@ def outside_defense_area() -> Play:
         aborted=invert_conditions(applicable),
         timeout_ms=0,
         roles=[
-            [AllowMoveInDefenseArea(DefendGoal())],
-            [CompositeOffense(tactic_default=WrapperLookBall(Position(-3.0, 2.0)))],
-            [CompositeOffense(tactic_default=WrapperLookBall(Position(-3.0, 0.0)))],
-            [CompositeOffense(tactic_default=WrapperLookBall(Position(-3.0, -2.0)))],
-            [CompositeOffense(tactic_default=WrapperLookBall(Position(0.0, 4.0)))],
-            [CompositeOffense(tactic_default=WrapperLookBall(Position(0.0, 2.0)))],
-            [CompositeOffense(tactic_default=WrapperLookBall(Position(0.0, -2.0)))],
-            [CompositeOffense(tactic_default=WrapperLookBall(Position(0.0, -4.0)))],
-            [CompositeOffense(tactic_default=WrapperLookBall(Position(3.0, 3.0)))],
-            [CompositeOffense(tactic_default=WrapperLookBall(Position(3.0, -3.0)))],
-            [CompositeOffense(tactic_default=WrapperLookBall(Position(4.0, 0.0)))],
+            [AllowMoveInDefenseArea(CompositeOffense(DefendGoal()))],
+            [CompositeOffense(tactic_default=WrapperLookBall(Position(3.0, 2.0)))],
+            [CompositeOffense(tactic_default=WrapperLookBall(Position(3.0, 0.0)))],
+            [CompositeOffense(tactic_default=WrapperLookBall(Position(3.0, -2.0)))],
+            [CompositeDefense(tactic_default=CenterBack())],
+            [CompositeDefense(tactic_default=CenterBack())],
+            [CompositeDefense(tactic_default=CenterBack())],
+            [CompositeDefense(tactic_default=CompositeManMark(tactic_default=WrapperLookBall(Position(-2.0, -2.0))))],
+            [CompositeDefense(tactic_default=CompositeManMark(tactic_default=WrapperLookBall(Position(-2.0, 2.0))))],
+            [CompositeDefense(tactic_default=CompositeManMark(tactic_default=WrapperLookBall(Position(-3.0, -4.0))))],
+            [CompositeDefense(tactic_default=CompositeManMark(tactic_default=WrapperLookBall(Position(-3.0, 4.0))))],
         ],
     )
 

--- a/consai_game/consai_game/tactic/composite/composite_defense.py
+++ b/consai_game/consai_game/tactic/composite/composite_defense.py
@@ -33,7 +33,7 @@ class CompositeDefense(TacticBase):
         self.tactic_receive = Receive()
         self.tactic_default = tactic_default
         self.diff_goal_threshold = 2.5
-        self.very_close_to_ball_threshold = 0.5
+        self.very_close_to_ball_threshold = 0.3
         self.do_receive = do_receive
 
     def reset(self, robot_id: int) -> None:

--- a/consai_game/consai_game/tactic/composite/composite_defense.py
+++ b/consai_game/consai_game/tactic/composite/composite_defense.py
@@ -1,0 +1,86 @@
+# Copyright 2025 Roots
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+条件に応じてディフェンス動作やキックやパスを切り替えるTactic
+"""
+
+from consai_game.core.tactic.tactic_base import TacticBase
+from consai_game.tactic.kick.kick import Kick
+from consai_game.tactic.receive import Receive
+from consai_game.world_model.world_model import WorldModel
+from consai_tools.geometry import geometry_tools as tool
+
+from consai_msgs.msg import MotionCommand
+
+
+class CompositeDefense(TacticBase):
+    def __init__(self, tactic_default: TacticBase):
+        super().__init__()
+        self.tactic_shoot = Kick(is_pass=False)
+        self.tactic_pass = Kick(is_pass=True)
+        self.tactic_receive = Receive()
+        self.tactic_default = tactic_default
+        self.diff_goal_threshold = 2.5
+
+    def reset(self, robot_id: int) -> None:
+        """Reset the tactic state for the specified robot."""
+        super().reset(robot_id)
+
+        # 所有するTacticも初期化する
+        self.tactic_shoot.reset(robot_id)
+        self.tactic_pass.reset(robot_id)
+        self.tactic_receive.reset(robot_id)
+        self.tactic_default.reset(robot_id)
+
+    def run(self, world_model: WorldModel) -> MotionCommand:
+        """状況に応じて実行するtacticを切り替えてrunする."""
+
+        diff_boll_to_goal = tool.get_distance(world_model.ball.pos, world_model.field_points.our_goal_center)
+        # ボールが動いている場合は、自分がレシーブできるかを判断する
+        best_receive_score = world_model.robot_activity.our_ball_receive_score[0]
+        if (
+            world_model.ball_activity.ball_is_moving
+            and best_receive_score.robot_id == self.robot_id
+            and best_receive_score.intercept_time != float("inf")
+        ):
+            # 自分がレシーブできる場合
+            return self.tactic_receive.run(world_model)
+
+        elif (
+            world_model.robot_activity.our_robots_by_ball_distance[0] == self.robot_id
+            and diff_boll_to_goal > self.diff_goal_threshold
+        ):
+            # ボールに一番近い、かつゴールからある程度遠い場合はボールを操作する
+            return self.control_the_ball(world_model)
+
+        # ボールに近くない場合はデフォルトのtacticを実行する
+        return self.tactic_default.run(world_model)
+
+    def control_the_ball(self, world_model: WorldModel) -> MotionCommand:
+        """ボールを制御するためのTacticを実行する関数."""
+
+        if world_model.kick_target.best_shoot_target.success_rate > 50:
+            # シュートできる場合
+            self.tactic_shoot.target_pos = world_model.kick_target.best_shoot_target.pos
+            return self.tactic_shoot.run(world_model)
+
+        elif world_model.kick_target.best_pass_target.success_rate > 30:
+            # パスできる場合
+            self.tactic_pass.target_pos = world_model.kick_target.best_pass_target.robot_pos
+            return self.tactic_pass.run(world_model)
+
+        # シュート成功率が一番高いところに向かってパスする(クリア)
+        self.tactic_pass.target_pos = world_model.kick_target.best_shoot_target.pos
+        return self.tactic_pass.run(world_model)

--- a/consai_game/consai_game/tactic/composite/composite_man_mark.py
+++ b/consai_game/consai_game/tactic/composite/composite_man_mark.py
@@ -112,16 +112,16 @@ class ManMarkAssignment:
 class CompositeManMark(TacticBase):
     assignment_module = ManMarkAssignment()
 
-    def __init__(self, default_tactic: TacticBase):
+    def __init__(self, tactic_default: TacticBase):
         super().__init__()
-        self.default_tactic = default_tactic
+        self.tactic_default = tactic_default
         self.man_mark_tactic = ManMark(-1)
         self.mark_target_id = -1
 
     def reset(self, robot_id: int):
         super().reset(robot_id)
 
-        self.default_tactic.reset(robot_id)
+        self.tactic_default.reset(robot_id)
         self.man_mark_tactic.reset(robot_id)
 
     def exit(self):
@@ -144,7 +144,7 @@ class CompositeManMark(TacticBase):
         new_target_id = current_pair.target_id if current_pair else None
         if new_target_id is None:
             # 担当がない場合はデフォルトのtacticを実行
-            return self.default_tactic.run(world_model)
+            return self.tactic_default.run(world_model)
         if new_target_id is not None and new_target_id != self.mark_target_id:
             # ターゲットが変わったら更新
             self.mark_target_id = new_target_id

--- a/consai_game/consai_game/world_model/field_model.py
+++ b/consai_game/consai_game/world_model/field_model.py
@@ -50,8 +50,10 @@ class FieldPoints:
     center: Point
     our_goal_top: Point
     our_goal_bottom: Point
+    our_goal_center: Point
     their_goal_top: Point
     their_goal_bottom: Point
+    their_goal_center: Point
     corners: Rectangle
     our_defense_area: Rectangle
     their_defense_area: Rectangle
@@ -67,8 +69,10 @@ class FieldPoints:
 
         our_goal_top = Point(-half_length, half_goal_width)
         our_goal_bottom = Point(-half_length, -half_goal_width)
+        our_goal_center = Point(-half_length, 0.0)
         their_goal_top = Point(half_length, half_goal_width)
         their_goal_bottom = Point(half_length, -half_goal_width)
+        their_goal_center = Point(half_length, 0.0)
 
         corners = Rectangle(
             top_left=Point(-half_length, half_width),
@@ -96,8 +100,10 @@ class FieldPoints:
             center=center,
             our_goal_top=our_goal_top,
             our_goal_bottom=our_goal_bottom,
+            our_goal_center=our_goal_center,
             their_goal_top=their_goal_top,
             their_goal_bottom=their_goal_bottom,
+            their_goal_center=their_goal_center,
             corners=corners,
             our_defense_area=our_defense_area,
             their_defense_area=their_defense_area,


### PR DESCRIPTION
ほとんどオフェンスの流用です

クリアではなく、一番シュート成功たかいとこにpassするようにしました。
そのほうがワンちゃんあるかなとおもって

すまとらと戦わせていたときのセットです
```
            [AllowMoveInDefenseArea(CompositeOffense(DefendGoal()))],
            [CompositeOffense(tactic_default=WrapperLookBall(Position(3.0, 2.0)))],
            [CompositeOffense(tactic_default=WrapperLookBall(Position(3.0, 0.0)))],
            [CompositeOffense(tactic_default=WrapperLookBall(Position(3.0, -2.0)))],
            [CompositeDefense(tactic_default=CenterBack())],
            [CompositeDefense(tactic_default=CenterBack())],
            [CompositeDefense(tactic_default=CenterBack())],
            [CompositeDefense(tactic_default=CompositeManMark(tactic_default=WrapperLookBall(Position(-2.0, -2.0))))],
            [CompositeDefense(tactic_default=CompositeManMark(tactic_default=WrapperLookBall(Position(-2.0, 2.0))))],
            [CompositeDefense(tactic_default=CompositeManMark(tactic_default=WrapperLookBall(Position(-3.0, -4.0))))],
            [CompositeDefense(tactic_default=CompositeManMark(tactic_default=WrapperLookBall(Position(-3.0, 4.0))))],
```

