### PR TITLE
Fix ball placement motion.

### DIFF
--- a/consai_game/consai_game/tactic/composite/composite_ball_placement.py
+++ b/consai_game/consai_game/tactic/composite/composite_ball_placement.py
@@ -36,7 +36,7 @@ class CompositeBallPlacement(TacticBase):
         self.tactic_dribble = Dribble()
         self.tactic_avoid_area_and_stay = ForbidMovingInPlacementArea(tactic=Stay())
         self.tactic_chase_ball = WithAvoidBallZone(ChaseBall())
-        self.tactic_approach_to_ball = MoveToBall(distance=0.1)
+        self.tactic_approach_to_ball = MoveToBall(distance=0.15)
         self.tactic_avoid_ball = MoveToBall(distance=0.6)
 
     def reset(self, robot_id: int) -> None:

--- a/consai_game/consai_game/tactic/composite/composite_ball_placement.py
+++ b/consai_game/consai_game/tactic/composite/composite_ball_placement.py
@@ -21,6 +21,7 @@ from consai_game.tactic.dribble import Dribble
 from consai_game.tactic.stay import Stay
 from consai_game.tactic.chase_ball import ChaseBall
 from consai_game.tactic.wrapper.forbid_moving_in_placement_area import ForbidMovingInPlacementArea
+from consai_game.tactic.wrapper.with_avoid_ball_zone import WithAvoidBallZone
 from consai_game.world_model.world_model import WorldModel
 from consai_tools.geometry import geometry_tools as tools
 
@@ -33,7 +34,7 @@ class CompositeBallPlacement(TacticBase):
         super().__init__()
         self.tactic_dribble = Dribble()
         self.tactic_avoid_and_stay = ForbidMovingInPlacementArea(tactic=Stay())
-        self.tactic_chase_ball = ChaseBall()
+        self.tactic_chase_ball = WithAvoidBallZone(ChaseBall())
 
     def reset(self, robot_id: int) -> None:
         """Reset the tactic state for the specified robot."""

--- a/consai_game/consai_game/tactic/dribble.py
+++ b/consai_game/consai_game/tactic/dribble.py
@@ -119,7 +119,6 @@ class Dribble(TacticBase):
         """Initialize the DefendGoal tactic."""
         super().__init__()
 
-        self.move_pos = State2D()
         self.target_pos = State2D(x=x, y=y)
         self.machine = DribbleStateMachine("robot")
 

--- a/consai_game/consai_game/tactic/dribble.py
+++ b/consai_game/consai_game/tactic/dribble.py
@@ -175,7 +175,7 @@ class Dribble(TacticBase):
 
     def ball_is_front(self, world_model: WorldModel) -> bool:
         """ボールがロボットの前にあるかどうかを判定する."""
-        FRONT_DIST_THRESHOLD = 0.1  # 正面方向にどれだけ離れることを許容するか
+        FRONT_DIST_THRESHOLD = 0.15  # 正面方向にどれだけ離れることを許容するか
         SIDE_DIST_THRESHOLD = 0.05  # 横方向にどれだけ離れることを許容するか
 
         robot_pos = world_model.robots.our_robots.get(self.robot_id).pos
@@ -218,7 +218,7 @@ class Dribble(TacticBase):
 
     def dribble_the_ball(self, command: MotionCommand, ball_pos: State2D, robot_pos: State2D) -> MotionCommand:
         """ボールをドリブルするコマンドを返す."""
-        DRIBBLING_VELOCITY = 0.5  # ドリブル時の速度[m/s]
+        DRIBBLING_VELOCITY = 0.8  # ドリブル時の速度[m/s]
         PLACING_VELOCITY = 0.1  # ボールを置くときの速度[m/s]
         PLACING_THRESHOLD = 0.5  # placingを始める距離
 

--- a/consai_game/consai_game/tactic/dribble.py
+++ b/consai_game/consai_game/tactic/dribble.py
@@ -21,7 +21,6 @@ Dribble Tactic.
 from consai_game.core.tactic.tactic_base import TacticBase
 from consai_game.core.tactic.tactic_base import TacticState
 from consai_game.world_model.world_model import WorldModel
-from consai_game.tactic.ball_approach import BallApproach
 
 from consai_msgs.msg import MotionCommand
 from consai_msgs.msg import State2D
@@ -82,23 +81,25 @@ class DribbleStateMachine(GraphMachine):
         dist_ball_to_target: float,
         dribble_diff_angle: float,
         ball_is_front: bool,
-        approach_finish: bool,
     ):
         """状態遷移."""
         if self.state == "arrived" and self.DIST_TARGET_TO_BALL_THRESHOLD < dist_ball_to_target:
+            # ボールがロボットから離れすぎている
             self.approach()
 
-        elif self.state == "approaching" and approach_finish:
+        elif self.state == "approaching" and ball_is_front:
+            # ボールがロボットの正面にある
             self.dribble()
 
         elif self.state == "dribbling" and (
-            self.DRIBBLE_ANGLE_THRESHOLD < dribble_diff_angle
-            or self.DRIBBLE_DIST < dist_robot_to_ball
-            or ball_is_front is False
+            self.DRIBBLE_ANGLE_THRESHOLD < dribble_diff_angle or self.DRIBBLE_DIST < dist_robot_to_ball
         ):
+            # ロボットがドリブル角度から外れる
+            # または、ロボットがボールから離れすぎている
             self.reapproach()
 
         elif self.state == "dribbling" and dist_ball_to_target < self.DIST_TARGET_TO_BALL_THRESHOLD:
+            # ボールが目的位置に到着する
             self.arrival()
 
 
@@ -122,14 +123,11 @@ class Dribble(TacticBase):
         self.target_pos = State2D(x=x, y=y)
         self.machine = DribbleStateMachine("robot")
 
-        self.ball_approach = BallApproach(x=x, y=y)
-
     def reset(self, robot_id: int) -> None:
         """Reset the tactic state for the specified robot."""
         self.robot_id = robot_id
         self.state = TacticState.RUNNING
         self.machine.reset()
-        self.ball_approach.reset(robot_id)
 
     def run(self, world_model: WorldModel) -> MotionCommand:
         """Run the tactic and return a MotionCommand based on the ball's position and movement."""
@@ -149,23 +147,15 @@ class Dribble(TacticBase):
         # ドリブル角度との差分を計算
         dribble_diff_angle = abs(tool.angle_normalize(robot_pos.theta - dribble_angle))
 
-        # ロボットを中心に、ターゲットを+x軸とした座標系を作る
-        trans = tool.Trans(robot_pos, tool.get_angle(robot_pos, self.target_pos))
-        tr_ball_pos = trans.transform(ball_pos)
-        # ボールがロボットの正面にあるか
-        ball_is_front = bool(tr_ball_pos.x > 0.0)  # convert numpy bool to python bool
-
-        # ball_approachが完了したか
-        approach_finish = self.ball_approach.machine.state == "arrived"
-
         # 状態遷移を更新
         self.machine.update(
             dist_robot_to_ball=dist_robot_to_ball,
             dist_ball_to_target=dist_ball_to_target,
             dribble_diff_angle=np.rad2deg(dribble_diff_angle),
-            ball_is_front=ball_is_front,
-            approach_finish=approach_finish,
+            ball_is_front=self.ball_is_front(world_model),
         )
+
+        print(f"state: {self.machine.state}")
 
         command = MotionCommand()
         command.robot_id = self.robot_id
@@ -175,10 +165,7 @@ class Dribble(TacticBase):
         command.navi_options.avoid_ball = False
 
         if self.machine.state == "approaching":
-            command = self.ball_approach.run(world_model)
-
-            # ドリブルOFF
-            command.dribble_power = self.DRIBBLE_OFF
+            command = self.approach_to_ball(command=command, world_model=world_model)
         elif self.machine.state == "dribbling":
             command = self.dribble_the_ball(command=command, world_model=world_model)
         else:
@@ -186,6 +173,50 @@ class Dribble(TacticBase):
             # ドリブルOFF
             command.dribble_power = self.DRIBBLE_OFF
 
+        return command
+
+    def ball_is_front(self, world_model: WorldModel) -> bool:
+        """ボールがロボットの前にあるかどうかを判定する."""
+        FRONT_DIST_THRESHOLD = 0.1  # 正面方向にどれだけ離れることを許容するか
+        SIDE_DIST_THRESHOLD = 0.05  # 横方向にどれだけ離れることを許容するか
+
+        robot_pos = world_model.robots.our_robots.get(self.robot_id).pos
+        ball_pos = world_model.ball.pos
+
+        # ロボットを中心に、ターゲットを+x軸とした座標系を作る
+        trans = tool.Trans(robot_pos, tool.get_angle(robot_pos, self.target_pos))
+        tr_ball_pos = trans.transform(ball_pos)
+
+        # ボールがロボットの後ろにある
+        if tr_ball_pos.x < 0:
+            return False
+
+        # ボールが正面から離れすぎている
+        if tr_ball_pos.x > FRONT_DIST_THRESHOLD:
+            return False
+
+        # ボールが横方向に離れすぎている
+        if abs(tr_ball_pos.y) > SIDE_DIST_THRESHOLD:
+            return False
+        return True
+
+    def approach_to_ball(self, command: MotionCommand, world_model: WorldModel) -> MotionCommand:
+        """ボールに近づくコマンドを返す."""
+        APPROACH_DIST = 0.09  # ボールに近づく距離。ロボットの半径と同じくらいにする
+        ball_pos = world_model.ball.pos
+
+        # ボールを中心にターゲットを+X軸とした座標系を作る
+        trans = tool.Trans(ball_pos, tool.get_angle(ball_pos, self.target_pos))
+
+        # ボールの後ろに目標位置を生成する
+        command.desired_pose = trans.inverted_transform(State2D(x=-APPROACH_DIST, y=0.0))
+        command.desired_pose.theta = trans.inverted_transform_angle(0.0)  # ボールからターゲットを見る角度
+
+        # ボール回避をONにして、ボールに回り込む
+        command.navi_options.avoid_ball = True
+
+        # ドリブルOFF
+        command.dribble_power = self.DRIBBLE_OFF
         return command
 
     def dribble_the_ball(self, command: MotionCommand, world_model: WorldModel) -> MotionCommand:

--- a/consai_game/consai_game/tactic/dribble.py
+++ b/consai_game/consai_game/tactic/dribble.py
@@ -154,7 +154,7 @@ class Dribble(TacticBase):
         trans = tool.Trans(robot_pos, tool.get_angle(robot_pos, self.target_pos))
         tr_ball_pos = trans.transform(ball_pos)
         # ボールがロボットの正面にあるか
-        ball_is_front = tr_ball_pos.x > 0.0
+        ball_is_front = bool(tr_ball_pos.x > 0.0)  # convert numpy bool to python bool
 
         # ball_approachが完了したか
         approach_finish = self.ball_approach.machine.state == "arrived"

--- a/consai_game/consai_game/tactic/dribble.py
+++ b/consai_game/consai_game/tactic/dribble.py
@@ -175,13 +175,10 @@ class Dribble(TacticBase):
         command.navi_options.avoid_ball = False
 
         if self.machine.state == "approaching":
-            # command = self.ball_approach.run(world_model)
+            command = self.ball_approach.run(world_model)
 
-            # # ドリブルOFF
-            # command.dribble_power = self.DRIBBLE_OFF
-
-            command = self.dribble_the_ball(command=command, world_model=world_model)
-
+            # ドリブルOFF
+            command.dribble_power = self.DRIBBLE_OFF
         elif self.machine.state == "dribbling":
             command = self.dribble_the_ball(command=command, world_model=world_model)
         else:

--- a/consai_game/consai_game/tactic/move_to_ball.py
+++ b/consai_game/consai_game/tactic/move_to_ball.py
@@ -1,0 +1,54 @@
+# Copyright 2025 Roots
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from consai_game.core.tactic.tactic_base import TacticBase
+from consai_game.world_model.world_model import WorldModel
+
+from consai_msgs.msg import MotionCommand
+from consai_msgs.msg import State2D
+
+from consai_tools.geometry import geometry_tools as tool
+
+
+class MoveToBall(TacticBase):
+    """ボールに近づくTactic.
+
+    ロボットの現在位置からまっすぐボールに近づく.
+    距離を調整すれば、ボールから離れる動作としても使用可能.
+    """
+
+    def __init__(self, distance=0.5):
+        super().__init__()
+
+        # ボールとの距離
+        self.distance = distance
+
+    def run(self, world_model: WorldModel) -> MotionCommand:
+        """ロボットからボールへ直線を引き、その線上でボールからdistanceだけ離れるコマンドを生成する."""
+        command = MotionCommand()
+        command.robot_id = self.robot_id
+        command.mode = MotionCommand.MODE_NAVI
+
+        # ボールの位置を取得
+        ball_pos = world_model.ball.pos
+        # ロボットの位置を取得
+        robot_pos = world_model.robots.our_robots.get(self.robot_id).pos
+
+        # ボールを中心に、ロボットを+X軸とする座標系を作る
+        trans = tool.Trans(ball_pos, tool.get_angle(ball_pos, robot_pos))
+
+        command.desired_pose = trans.inverted_transform(State2D(x=self.distance, y=0.0))
+        command.desired_pose.theta = tool.get_angle(robot_pos, ball_pos)  # ボールの方向を向く
+
+        return command

--- a/consai_game/consai_game/world_model/visualize_msg_publisher_node.py
+++ b/consai_game/consai_game/world_model/visualize_msg_publisher_node.py
@@ -78,7 +78,7 @@ class VisualizeMsgPublisherNode(Node):
                 line.color.name = "red"
 
             # シュート成功率が高いほど色を刻する
-            line.color.alpha = min(1.0, target.success_rate / 100.0)
+            line.color.alpha = max(min(1.0, target.success_rate / 100.0), 0.0)
             line.caption = f"rate: {target.success_rate}"
 
             vis_obj.lines.append(line)
@@ -99,7 +99,7 @@ class VisualizeMsgPublisherNode(Node):
                 line.size = 2
 
             # シュート成功率が高いほど色を刻する
-            line.color.alpha = min(1.0, target.success_rate / 100.0)
+            line.color.alpha = max(min(1.0, target.success_rate / 100.0), 0.0)
             line.caption = f"rate: {target.success_rate}"
 
             vis_obj.lines.append(line)


### PR DESCRIPTION
ボールプレースメントの動きが不安定だったので修正します。

# 変更点

## consai_game/consai_game/tactic/composite/composite_ball_placement.py

- ボールが目的位置についたとき、2台のロボットがボールからまっすぐ逃げるようにtacticを変更します
- ドリブル速度をdribble tactic内で調整するように変更します

## consai_game/consai_game/tactic/dribble.py

- 衝突回避のボール回避機能でボールを避けながらapproachします
  - approach_ballを調整したかったのですが、複雑だったので別タスクとします。
- ball_next_posの使用をやめます
  - ボール速度基準で座標が作られるので、ボール停止時の挙動が不安定です
- ドリブルの動作を、目的位置からの距離に応じて2つに分けます
  - 目的位置に近づいたら、ドリブルをオフにしてゆっくり接近します
  - これにより、ドリブル終了後のボール移動を抑えられます

## consai_game/consai_game/tactic/move_to_ball.py

ロボットの現在位置からボールへまっすぐ進むTacticです。

ボールへの接近と回避に使用します。

## consai_game/consai_game/world_model/visualize_msg_publisher_node.py

alphaがマイナスになる警告が出てたのでついでに直しました。

# できてないこと

プレースメントエリア付近でボールを動かすと、2台のロボットの交代が頻発します。

これは、ボールアプローチ時にボールを大きく回避することで、ボールとロボットの距離が変わるためです。

やはり、ボールアプローチはいい感じに仕上げる必要があります。