### PR TITLE
Fix pass action

### DIFF
--- a/consai_game/consai_game/world_model/kick_target_model.py
+++ b/consai_game/consai_game/world_model/kick_target_model.py
@@ -138,7 +138,7 @@ class KickTargetModel:
         """スコアの高いターゲット順にソートする関数."""
         return sorted(targets, key=attrgetter("success_rate"), reverse=True)
 
-    def _search_shoot_pos(self, ball: BallModel, robots: RobotsModel, search_ours=True) -> ShootTarget:
+    def _search_shoot_pos(self, ball: BallModel, robots: RobotsModel, search_ours=False) -> ShootTarget:
         """ボールからの直線上にロボットがいないシュート位置を返す関数."""
         RATE_MARGIN = 50  # ヒステリシスのためのマージン
         last_shoot_target_list = self.shoot_target_list.copy()


### PR DESCRIPTION
search_shoot_pos関数でデフォルトで味方ロボットを障
害物として計算しないように設定しました。
これにより、ボール基準で相手ゴール側にいる味方ロボットが障害物判定されなくなり、パスを受けたロボットが障害物として認識されなくなりました。

なので優勝です