### PR TITLE
ボールに近づいた時ドリブラーを回すよう変更

### DIFF
--- a/consai_game/consai_game/tactic/kick/kick.py
+++ b/consai_game/consai_game/tactic/kick/kick.py
@@ -84,7 +84,7 @@ class Kick(TacticBase):
 
     ANGLE_BALL_TO_ROBOT_THRESHOLD = 120  # ボールが後方に居るとみなす角度[degree]
     ANGLE_FOR_PIVOT_POS = ANGLE_BALL_TO_ROBOT_THRESHOLD + 10  # ボールの後側に移動するための角度[degree]
-    DRIBBLE_ON = 1.0 # ドリブルON時の出力
+    DRIBBLE_ON = 1.0  # ドリブルON時の出力
 
     def __init__(self, x=0.0, y=0.0, is_pass=False, is_tapping=False, is_setplay=True):
         """

--- a/consai_game/consai_game/tactic/kick/kick.py
+++ b/consai_game/consai_game/tactic/kick/kick.py
@@ -84,6 +84,7 @@ class Kick(TacticBase):
 
     ANGLE_BALL_TO_ROBOT_THRESHOLD = 120  # ボールが後方に居るとみなす角度[degree]
     ANGLE_FOR_PIVOT_POS = ANGLE_BALL_TO_ROBOT_THRESHOLD + 10  # ボールの後側に移動するための角度[degree]
+    DRIBBLE_ON = 1.0 # ドリブルON時の出力
 
     def __init__(self, x=0.0, y=0.0, is_pass=False, is_tapping=False, is_setplay=True):
         """
@@ -166,6 +167,8 @@ class Kick(TacticBase):
                 command.desired_pose = self.kicking_pose(
                     ball_pos=ball_pos, distance=0.15, target_pos=self.final_target_pos
                 )
+                # ドリブラーON
+                command.dribble_power = self.DRIBBLE_ON
 
         elif self.machine.state == "kicking":
             # ボールを蹴る

--- a/consai_game/consai_game/tactic/kick/kick.py
+++ b/consai_game/consai_game/tactic/kick/kick.py
@@ -158,6 +158,8 @@ class Kick(TacticBase):
         elif self.machine.state == "aiming":
             # 蹴る方向に向けて移動
             command.navi_options.avoid_pushing = False
+            # ドリブラーON
+            command.dribble_power = self.DRIBBLE_ON
             if self.is_setplay:
                 # セットプレイならちょっと位置を離す
                 command.desired_pose = self.kicking_pose(
@@ -167,13 +169,14 @@ class Kick(TacticBase):
                 command.desired_pose = self.kicking_pose(
                     ball_pos=ball_pos, distance=0.15, target_pos=self.final_target_pos
                 )
-                # ドリブラーON
-                command.dribble_power = self.DRIBBLE_ON
 
         elif self.machine.state == "kicking":
             # ボールを蹴る
             command.navi_options.avoid_pushing = False
             command.desired_pose = self.kicking_pose(ball_pos=ball_pos, distance=0.04, target_pos=self.final_target_pos)
+            # ドリブラーON
+            command.dribble_power = self.DRIBBLE_ON
+            # キックパワーの設定
             command.kick_power = self.MAX_KICK_POWER
             if self.is_pass:
                 command.kick_power = self.pass_power(ball_pos, target_pos=self.final_target_pos)


### PR DESCRIPTION
チケット：https://github.com/orgs/SSL-Roots/projects/7/views/1?pane=issue&itemId=108955286

インプレイでのaimingとkickingでドリブラーがONになる