### PR TITLE
Use dummy ball position at placement when ball is not visible

### DIFF
--- a/consai_game/consai_game/tactic/composite/composite_ball_placement.py
+++ b/consai_game/consai_game/tactic/composite/composite_ball_placement.py
@@ -26,6 +26,7 @@ from consai_game.tactic.wrapper.with_avoid_ball_zone import WithAvoidBallZone
 from consai_game.world_model.world_model import WorldModel
 from consai_tools.geometry import geometry_tools as tools
 from consai_game.tactic.back_dribble import BackDribble
+from consai_game.utils.generate_dummy_ball_position import generate_dummy_ball_position
 
 from consai_msgs.msg import MotionCommand
 from consai_msgs.msg import State2D
@@ -130,8 +131,10 @@ class CompositeBallPlacement(TacticBase):
         # ボールがフィールド外にあるか
         target_pos = deepcopy(world_model.referee.placement_pos)
         need_back_dribble = False
+        robot_pos = world_model.robots.our_robots.get(self.robot_id).pos
 
-        ball_pos = world_model.ball.pos
+        # ボールが消えることを想定して、仮想的なボール位置を生成する
+        ball_pos = generate_dummy_ball_position(ball=world_model.ball, robot_pos=robot_pos)
         if world_model.ball_position.is_outside_of_top():
             # ボールがフィールドの上にあったら、ボールの下にドリブルする
             need_back_dribble = True

--- a/consai_game/consai_game/utils/generate_dummy_ball_position.py
+++ b/consai_game/consai_game/utils/generate_dummy_ball_position.py
@@ -1,0 +1,37 @@
+# Copyright 2025 Roots
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+ボールが消えたことを想定して、仮想的なボール位置を生成するモジュール
+"""
+
+from consai_game.world_model.ball_model import BallModel
+from consai_msgs.msg import State2D
+from consai_tools.geometry import geometry_tools as tool
+
+
+def generate_dummy_ball_position(ball: BallModel, robot_pos: State2D) -> State2D:
+    """ボールが消えていた場合、ロボットがボールを持っている前提の位置を返す"""
+
+    # ボールが見えていたらそのまま返す
+    if ball.is_visible:
+        return ball.pos
+
+    dist_robot_to_ball = 0.10
+
+    # ロボットを中心に、ロボットの向きをX+軸とする座標系を作る
+    trans = tool.Trans(robot_pos, robot_pos.theta)
+
+    # ロボットの前方、ドリブラー付近にボールがあると仮定する
+    return trans.inverted_transform(State2D(x=dist_robot_to_ball, y=0.0))


### PR DESCRIPTION

ボールプレースメントでボールが消えたときの対策です。

ダミーのボール位置を算出するgenerate_dummy_ball_positionを、ボールプレースメントや、ドリブルに適用します。

これにより、ballがnot is_visibleのときは、"ロボットのドリブラー位置"にボールがあると仮定して、プレースメントを実施できます。

## テスト方法

いい感じのタイミングで、grsimのVanishingをON/OFFします

## 懸念点

ボールが全くvisibleにならない場合、永遠と仮想位置を算出するため、プレースメントが終わりません。

ボールがフィールド外に出たという判定は、ball_position_modelを使っています。ここには仮想位置を適用できないので、なにか障害があるかもしれません。
