### PR TITLE
ball placement時にゴーリーがディフェンスエリア回避をしないよう変更

### DIFF
--- a/consai_game/consai_game/play/factory/simple_plays.py
+++ b/consai_game/consai_game/play/factory/simple_plays.py
@@ -507,7 +507,7 @@ def our_ball_placement() -> Play:
         aborted=invert_conditions(applicable),
         timeout_ms=0,
         roles=[
-            [CompositeBallPlacement()],
+            [AllowMoveInDefenseArea(CompositeBallPlacement())],
             [CompositeBallPlacement()],
             [CompositeBallPlacement()],
             [CompositeBallPlacement()],


### PR DESCRIPTION
チケット：https://github.com/orgs/SSL-Roots/projects/7?pane=issue&itemId=108995085

単純に設定を忘れていた