### PR TITLE
Stop using bounded array type

### DIFF
--- a/robocup_ssl_msgs/msg/detection/DetectionBall.msg
+++ b/robocup_ssl_msgs/msg/detection/DetectionBall.msg
@@ -2,9 +2,9 @@
 # https://github.com/RoboCup-SSL/ssl-vision/blob/master/src/shared/proto/messages_robocup_ssl_detection.proto
 
 float32 confidence
-uint32[<=1] area  # optional
+uint32[] area  # optional
 float32 x
 float32 y
-float32[<=1] z  # optional
+float32[] z  # optional
 float32 pixel_x
 float32 pixel_y

--- a/robocup_ssl_msgs/msg/detection/DetectionRobot.msg
+++ b/robocup_ssl_msgs/msg/detection/DetectionRobot.msg
@@ -2,10 +2,10 @@
 # https://github.com/RoboCup-SSL/ssl-vision/blob/master/src/shared/proto/messages_robocup_ssl_detection.proto
 
 float32 confidence
-uint32[<=1] robot_id  # optional
+uint32[] robot_id  # optional
 float32 x
 float32 y
-float32[<=1] orientation  # optional
+float32[] orientation  # optional
 float32 pixel_x
 float32 pixel_y
-float32[<=1] height  # optional
+float32[] height  # optional

--- a/robocup_ssl_msgs/msg/detection_tracked/KickedBall.msg
+++ b/robocup_ssl_msgs/msg/detection_tracked/KickedBall.msg
@@ -11,9 +11,9 @@ Vector3 vel
 float64 start_timestamp
 
 # The predicted unix timestamp [s] when the ball comes to a stop
-float64[<=1] stop_timestamp  # optional
+float64[] stop_timestamp  # optional
 # The predicted position [m] at which the ball will come to a stop
-Vector2[<=1] stop_pos  # optional
+Vector2[] stop_pos  # optional
 
 # The robot that kicked the ball
-RobotId[<=1] robot_id  # optional
+RobotId[] robot_id  # optional

--- a/robocup_ssl_msgs/msg/detection_tracked/TrackedBall.msg
+++ b/robocup_ssl_msgs/msg/detection_tracked/TrackedBall.msg
@@ -7,9 +7,9 @@
 Vector3 pos
 
 # The velocity [m/s] in the ssl-vision coordinate system
-Vector3[<=1] vel  # optional
+Vector3[] vel  # optional
 
 # The visibility of the ball
 # A value between 0 (not visible) and 1 (visible)
 # The exact implementation depends on the source software
-float32[<=1] visibility  #optional
+float32[] visibility  #optional

--- a/robocup_ssl_msgs/msg/detection_tracked/TrackedFrame.msg
+++ b/robocup_ssl_msgs/msg/detection_tracked/TrackedFrame.msg
@@ -23,7 +23,7 @@ TrackedRobot[] robots
 
 # Information about a kicked ball, if the ball was kicked by a robot and is still moving
 # Note: This field is optional. Some source implementations might not set this at any time
-KickedBall[<=1] kicked_ball  # optional
+KickedBall[] kicked_ball  # optional
 
 # List of capabilities of the source implementation
 uint32[] capabilities

--- a/robocup_ssl_msgs/msg/detection_tracked/TrackedRobot.msg
+++ b/robocup_ssl_msgs/msg/detection_tracked/TrackedRobot.msg
@@ -11,11 +11,11 @@ Vector2 pos
 float32 orientation
 
 # The velocity [m/s] in the ssl-vision coordinate system
-Vector2[<=1] vel  # optional
+Vector2[] vel  # optional
 # The angular velocity [rad/s] in the ssl-vision coordinate system
-float32[<=1] vel_angular  # optional
+float32[] vel_angular  # optional
 
 # The visibility of the robot
 # A value between 0 (not visible) and 1 (visible)
 # The exact implementation depends on the source software
-float32[<=1] visibility  # optional
+float32[] visibility  # optional

--- a/robocup_ssl_msgs/msg/geometry/FieldCircularArc.msg
+++ b/robocup_ssl_msgs/msg/geometry/FieldCircularArc.msg
@@ -24,4 +24,4 @@ float32 radius
 float32 a1
 float32 a2
 float32 thickness
-uint32[<=1] type  # optional
+uint32[] type  # optional

--- a/robocup_ssl_msgs/msg/geometry/FieldLineSegment.msg
+++ b/robocup_ssl_msgs/msg/geometry/FieldLineSegment.msg
@@ -24,4 +24,4 @@ string name
 Vector2f p1
 Vector2f p2
 float32 thickness
-uint32[<=1] type  # optional
+uint32[] type  # optional

--- a/robocup_ssl_msgs/msg/geometry/GeometryCameraCalibration.msg
+++ b/robocup_ssl_msgs/msg/geometry/GeometryCameraCalibration.msg
@@ -13,8 +13,8 @@ float32 q3
 float32 tx
 float32 ty
 float32 tz
-float32[<=1] derived_camera_world_tx  # optional
-float32[<=1] derived_camera_world_ty  # optional
-float32[<=1] derived_camera_world_tz  # optional
-uint32[<=1] pixel_image_width  # optional
-uint32[<=1] pixel_image_height  # optional
+float32[] derived_camera_world_tx  # optional
+float32[] derived_camera_world_ty  # optional
+float32[] derived_camera_world_tz  # optional
+uint32[] pixel_image_width  # optional
+uint32[] pixel_image_height  # optional

--- a/robocup_ssl_msgs/msg/geometry/GeometryData.msg
+++ b/robocup_ssl_msgs/msg/geometry/GeometryData.msg
@@ -3,4 +3,4 @@
 
 GeometryFieldSize field
 GeometryCameraCalibration[] calib
-GeometryModels[<=1] models  # optional
+GeometryModels[] models  # optional

--- a/robocup_ssl_msgs/msg/geometry/GeometryFieldSize.msg
+++ b/robocup_ssl_msgs/msg/geometry/GeometryFieldSize.msg
@@ -8,5 +8,5 @@ int32 goal_depth
 int32 boundary_width
 FieldLineSegment[] field_lines
 FieldCircularArc[] field_arcs
-int32[<=1] penalty_area_depth  # optional
-int32[<=1] penalty_area_width  # optional
+int32[] penalty_area_depth  # optional
+int32[] penalty_area_width  # optional

--- a/robocup_ssl_msgs/msg/geometry/GeometryModels.msg
+++ b/robocup_ssl_msgs/msg/geometry/GeometryModels.msg
@@ -1,5 +1,5 @@
 # This msg file is a copy of 'messages_robocup_ssl_geometry.proto'
 # https://github.com/RoboCup-SSL/ssl-vision/blob/master/src/shared/proto/messages_robocup_ssl_geometry.proto
 
-BallModelStraightTwoPhase[<=1] straight_two_phase  # optional
-BallModelChipFixedLoss[<=1] chip_fixed_loss  # optional
+BallModelStraightTwoPhase[] straight_two_phase  # optional
+BallModelChipFixedLoss[] chip_fixed_loss  # optional


### PR DESCRIPTION
## 概要

- メッセージでの範囲指定配列の使用をやめます。

- plot juggler（データプロットツールの一つ）で、範囲指定配列を扱えないという不具合があるため、このPRを取り入れたいです。：

Related issue：https://github.com/facontidavide/PlotJuggler/issues/881

## 関連チケット

- チケットURL: なし


## 変更内容

`hoge[<=1]`のように範囲指定でメンバを定義しているメッセージファイルを修正します

## 動作確認内容

- [x] ビルドが通ること
- [x] 手動での動作確認（該当箇所の実行結果など）

`plotjuggler`でdetectionトピックを描画できることを確認しました

```sh
$ sudo apt install ros-$ROS_DISTRO-plotjuggler-ros
$ ros2 run plotjuggler plotjuggler
```

<img width="1050" height="843" alt="image" src="https://github.com/user-attachments/assets/a79d12b5-57f3-469c-a6be-1f7604171112" />


### 確認したReferee Command

- [x] HALT
- [x] STOP
- [x] FORCE_START
- [ ] OUR_FREEKICK
- [ ] THEIR_FREEKICK
- [ ] OUR KICKOFF
- [ ] THEIR KICKOFF
- [ ] OUR_PENALTY
- [ ] THEIR_PENALTY
- [ ] OUR_TIMEOUT
- [ ] THEIR_TIMEOUT

## 影響範囲

- どのモジュールや機能に影響を及ぼす可能性があるかを記載してください.
- 他のコントリビュータの作業に影響する変更がある場合は特に明示してください.

範囲指定を使ったコードは存在しないので、動作には影響ないです。

## 補足

- レビューの際に注意してほしい点や，伝えておきたい設計意図などがあれば記載してください.

CIが通ってたら大丈夫です。